### PR TITLE
docs(README.md): remove warning `Synchronous scripts should not be used.` for Next.js App router

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
+        <script src="https://unpkg.com/react-scan/dist/auto.global.js" async />
         {/* rest of your scripts go under */}
       </head>
       <body>{children}</body>


### PR DESCRIPTION
Remove warning `Synchronous scripts should not be used. See: https://nextjs.org/docs/messages/no-sync-scripts` for Next.js App router.

The docs recommend to not use synchronous scripts because I can impact webpage performance. 

I've checked with Next.js 14.2.1 and App router, and

```
<script src="https://unpkg.com/react-scan/dist/auto.global.js" async />
```

works.
