### PR TITLE
export the "Options" interface

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,7 +13,7 @@ import { createToolbar } from './web/toolbar';
 import { playGeigerClickSound } from './web/geiger';
 import { createPerfObserver } from './web/perf-observer';
 
-interface Options {
+export interface Options {
   /**
    * Enable/disable scanning
    *


### PR DESCRIPTION
First, love the package 🤗  great stuff y'all. 

As I was getting this setup for some Remix apps in a monorepo I wanted to pull a hook out into a custom library. These would be useful to expose for TypeScript consumers (easy win). 

- https://github.com/aidenybai/react-scan/issues/30
- https://github.com/aidenybai/react-scan/issues/26

```tsx
import { useEffect } from 'react';
import type { Options } from 'react-scan';

export const useReactScan = (options: Options) => {
  useEffect(() => {
    if (typeof document === 'undefined') return;

    import('react-scan').then(({ scan }) => {
      scan(options);
    });
  }, []);
};
```