### PR TITLE
Fix #41 issue and #42(duplicate of #41), scroll-bar global styles.

### DIFF
--- a/src/core/web/toolbar.ts
+++ b/src/core/web/toolbar.ts
@@ -397,30 +397,30 @@ export const createToolbar = (): () => void => {
     background: rgba(255, 255, 255, 0.3);
   }
 
-  ::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
-}
-
-::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.4);
-}
-
-/* For Firefox */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
-}
+  #react-scan-toolbar::-webkit-scrollbar {
+	  width: 4px;
+	  height: 4px;
+	}
+	
+	#react-scan-toolbar::-webkit-scrollbar-track {
+	  background: rgba(255, 255, 255, 0.1);
+	  border-radius: 4px;
+	}
+	
+	#react-scan-toolbar::-webkit-scrollbar-thumb {
+	  background: rgba(255, 255, 255, 0.3);
+	  border-radius: 4px;
+	}
+	
+	#react-scan-toolbar::-webkit-scrollbar-thumb:hover {
+	  background: rgba(255, 255, 255, 0.4);
+	}
+	
+	/* For Firefox */
+	#react-scan-toolbar * {
+	  scrollbar-width: thin;
+	  scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
+	}
   `;
 
   if (document.head) document.head.appendChild(styleElement);


### PR DESCRIPTION
Fix the issue [#41](https://github.com/aidenybai/react-scan/issues/41) and duplicate [#42](https://github.com/aidenybai/react-scan/issues/42)  
Bug the styles of **react-scan** `scroll-bar` styles redefines normal styles of `scroll-bar` in projects that uses **react-scan**

Issue is due to define **react-scan** `scroll-bar` global styles in file `src/core/web/toolbar`, so the solution is to define those styles of the `scroll-bar` to target the local `<div>` with id `#react-scan-toolbar`  

You can see in the picture below that the the `scroll-bar` of my project is normal and the `scroll-bar` of **react-scan** still well.
![solution_react_scan](https://github.com/user-attachments/assets/81cf1fb1-1560-4b25-a2d7-a28e8ccfbffb)
