### PR TITLE
refactor(core): simplify toolbar bounds checking logic

### DIFF
--- a/src/core/web/toolbar.ts
+++ b/src/core/web/toolbar.ts
@@ -482,46 +482,26 @@ export const createToolbar = (): (() => void) => {
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
 
-    const edges = [
-      {
-        edge: 'left',
-        distance: Math.abs(toolbarRect.left - EDGE_PADDING),
-        deltaX: EDGE_PADDING - toolbarRect.left,
-        deltaY: 0,
-      },
-      {
-        edge: 'right',
-        distance: Math.abs(viewportWidth - EDGE_PADDING - toolbarRect.right),
-        deltaX: viewportWidth - EDGE_PADDING - toolbarRect.right,
-        deltaY: 0,
-      },
-      {
-        edge: 'top',
-        distance: Math.abs(toolbarRect.top - EDGE_PADDING),
-        deltaX: 0,
-        deltaY: EDGE_PADDING - toolbarRect.top,
-      },
-      {
-        edge: 'bottom',
-        distance: Math.abs(viewportHeight - EDGE_PADDING - toolbarRect.bottom),
-        deltaX: 0,
-        deltaY: viewportHeight - EDGE_PADDING - toolbarRect.bottom,
-      },
-    ];
+    const maxX = viewportWidth - toolbarRect.width - EDGE_PADDING;
+    const maxY = viewportHeight - toolbarRect.height - EDGE_PADDING;
 
-    const closestEdge = edges.reduce((prev, curr) =>
-      curr.distance < prev.distance ? curr : prev,
-    );
+    const newX = Math.min(maxX, Math.max(EDGE_PADDING, toolbarRect.left));
+    const newY = Math.min(maxY, Math.max(EDGE_PADDING, toolbarRect.top));
 
-    currentX += closestEdge.deltaX;
-    currentY += closestEdge.deltaY;
+    const deltaX = newX - toolbarRect.left;
+    const deltaY = newY - toolbarRect.top;
+    // Only update if position changed
+    if (deltaX !== 0 || deltaY !== 0) {
+      currentX += deltaX;
+      currentY += deltaY;
 
-    toolbar.style.transition = `transform ${ANIMATION_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`;
-    updateToolbarPosition(currentX, currentY);
+      toolbar.style.transition = `transform ${ANIMATION_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+      updateToolbarPosition(currentX, currentY);
 
-    setTimeout(() => {
-      toolbar.style.transition = '';
-    }, ANIMATION_DURATION);
+      setTimeout(() => {
+        toolbar.style.transition = '';
+      }, ANIMATION_DURATION);
+    }
   };
 
   toolbarContent.addEventListener('mousedown', (event: any) => {


### PR DESCRIPTION
Problem
Quickly dragging the toolbar can move it outside the screen area.

Adjust

- Extract boundary calculations to improve readability
- Use position delta to determine updates

Now you can freely drag the toolbar without worrying about it going out of sight.