### PR TITLE
fix: resolve TypeScript issue with interval type

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -242,7 +242,8 @@ const init = async () => {
   let currentSpinner: ReturnType<typeof spinner> | undefined;
   let currentURL = urlString;
 
-  let interval: NodeJS.Timeout | undefined;
+  let interval: NodeJS.Timer | undefined;
+
   const inject = async (url: string) => {
     if (interval) clearInterval(interval);
     currentURL = url;
@@ -251,23 +252,29 @@ const init = async () => {
     currentSpinner = spinner();
     currentSpinner.start(dim(`Scanning: ${truncatedURL}`));
     count = 0;
+
     try {
       await page.waitForLoadState('load');
       await page.waitForTimeout(500);
+
       const hasReactScan = await page.evaluate(() => {
         return Boolean(globalThis.__REACT_SCAN__);
       });
+
       if (!hasReactScan) {
         await page.addScriptTag({
           content: scriptContent,
         });
       }
+
       await page.waitForTimeout(100);
+
       await page.evaluate(() => {
         if (typeof globalThis.reactScan !== 'function') return;
         globalThis.reactScan({ report: true });
         globalThis.__REACT_SCAN__.ReactScanInternals.reportData = {};
       });
+
       interval = setInterval(() => {
         pollReport().catch(() => {});
       }, 1000);


### PR DESCRIPTION
### Fix TypeScript Timer Type Issue

- Replaced `NodeJS.Timeout` with `NodeJS.Timer` to handle both `setTimeout()` and `setInterval()` correctly.
- This change resolves type errors and ensures compatibility with both one-time and recurring timers.
