### PR TITLE
fix: improve canvas clearing in inspect state machine

### DIFF
--- a/packages/scan/src/core/instrumentation/init.ts
+++ b/packages/scan/src/core/instrumentation/init.ts
@@ -1,8 +1,5 @@
 import type { FiberRoot } from 'react-reconciler';
-
-const NO_OP = () => {
-  /**/
-};
+import { NO_OP } from '../utils';
 
 export const registerDevtoolsHook = ({
   onCommitFiberRoot,

--- a/packages/scan/src/core/utils.ts
+++ b/packages/scan/src/core/utils.ts
@@ -1,5 +1,9 @@
 import type { Render } from './instrumentation/index';
 
+export const NO_OP = () => {
+  /**/
+};
+
 export const getLabelText = (renders: Array<Render>) => {
   let labelText = '';
 


### PR DESCRIPTION
This change provides a more reliable solution for canvas clearing when transitioning between inspection states, preventing artifacts and improving performance.