### PR TITLE
transpile to es2018

### DIFF
--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -96,7 +96,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "browser": "dist/auto.global.js",
+  "browser": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": "bin/cli.js",
   "files": [

--- a/packages/scan/tsup.config.ts
+++ b/packages/scan/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig([
     splitting: false,
     sourcemap: false,
     format: ['cjs', 'esm', 'iife'],
-    target: 'esnext',
+    target: 'es2018',
     platform: 'browser',
     treeshake: true,
     dts: true,


### PR DESCRIPTION
I've been using `react-scan` in a project with a legacy webpack 4 build, and noticed that the NPM dist uses modern syntax that can't be parsed. To work around, I've been running `react-scan` through babel-loader, but this PR should fix the problem.

It seems that webpack 4 uses acorn@6 to parse JS, and that it only supports es2018 syntax[^1]. Changing the compilation target for `esnext` to `es2018` fixes the issue, and doesn't affect the build size too much (52kb -> 54kb).

Tested with a trivial webpack 4 config:

| Before | After |
| -- | -- |
| <img width="1271" alt="Screenshot 2024-12-05 at 6 58 18 PM" src="https://github.com/user-attachments/assets/b97b92a9-ba65-4759-9d03-b3c1be44fde4"> | <img width="962" alt="Screenshot 2024-12-05 at 6 58 57 PM" src="https://github.com/user-attachments/assets/a039792f-383b-4ef3-a853-313b6c34f06a"> |


[^1]: https://github.com/acornjs/acorn/blob/6.x/acorn/README.md