### PR TITLE
feat(scan): add Astro monitoring component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/extension/build/
 !packages/extension/build/react-scan-extension.zip
 *.log
 build
+playgrounds

--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -173,6 +173,9 @@
       "monitoring/remix": [
         "./dist/core/monitor/params/remix.d.ts"
       ],
+      "monitoring/astro": [
+        "./dist/core/monitor/params/astro/index.ts"
+      ],
       "react-component-name/vite": [
         "./dist/react-component-name/vite.d.ts"
       ],

--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -51,6 +51,9 @@
       "import": "./dist/core/monitor/params/remix.mjs",
       "require": "./dist/core/monitor/params/remix.js"
     },
+    "./monitoring/astro": {
+      "import": "./dist/core/monitor/params/astro/index.ts"
+    },
     ".": {
       "production": {
         "import": {
@@ -200,9 +203,11 @@
     "auto.d.ts"
   ],
   "scripts": {
+    "copy-astro": "cp -R src/core/monitor/params/astro dist/core/monitor/params",
+    "postbuild": "pnpm copy-astro",
     "build": "NODE_ENV=production tsup",
     "build:copy": "NODE_ENV=production tsup && cat dist/auto.global.js | pbcopy",
-    "dev": "NODE_ENV=development tsup --watch",
+    "dev": "pnpm copy-astro & NODE_ENV=development tsup --watch",
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
     "pack": "npm version patch && pnpm build && npm pack",
     "pack:bump": "bun scripts/bump-version.js && nr pack && echo $(pwd)/react-scan-$(node -p \"require('./package.json').version\").tgz | pbcopy",

--- a/packages/scan/src/core/monitor/params/astro/Monitoring.astro
+++ b/packages/scan/src/core/monitor/params/astro/Monitoring.astro
@@ -1,0 +1,16 @@
+---
+// @ts-ignore This file will not be packaged, so the file to be imported should be a .mjs file.
+import { AstroMonitor } from './component.mjs';
+
+interface Props {
+  url?: string;
+  apiKey: string;
+}
+
+const { apiKey, url } = Astro.props;
+
+const pathname = Astro.url.pathname;
+const params = Astro.params;
+---
+
+<AstroMonitor apiKey={apiKey} url={url} pathname={pathname} params={params} client:only="react" />

--- a/packages/scan/src/core/monitor/params/astro/component.ts
+++ b/packages/scan/src/core/monitor/params/astro/component.ts
@@ -1,0 +1,19 @@
+import { createElement } from 'react';
+import { BaseMonitor } from '../..';
+import { computeRoute } from '../utils';
+
+export function AstroMonitor(props: {
+  url?: string;
+  apiKey: string;
+  pathname: string;
+  params: Record<string, string>;
+}) {
+  const path = props.pathname;
+  const route = computeRoute(path, props.params);
+
+  return createElement(BaseMonitor, {
+    ...props,
+    route,
+    path,
+  });
+}

--- a/packages/scan/src/core/monitor/params/astro/index.ts
+++ b/packages/scan/src/core/monitor/params/astro/index.ts
@@ -1,0 +1,4 @@
+// This file will not be packaged
+
+// eslint-disable-next-line no-useless-rename
+export { default as default } from './Monitoring.astro';

--- a/packages/scan/src/core/monitor/params/astro/index.ts
+++ b/packages/scan/src/core/monitor/params/astro/index.ts
@@ -1,4 +1,3 @@
 // This file will not be packaged
 
-// eslint-disable-next-line no-useless-rename
-export { default as default } from './Monitoring.astro';
+export { default as Monitoring } from './Monitoring.astro';

--- a/packages/scan/tsup.config.ts
+++ b/packages/scan/tsup.config.ts
@@ -38,6 +38,7 @@ export default defineConfig([
       './src/core/monitor/params/react-router-v5.ts',
       './src/core/monitor/params/react-router-v6.ts',
       './src/core/monitor/params/remix.ts',
+      './src/core/monitor/params/astro/component.ts',
     ],
     outDir: DIST_PATH,
     splitting: false,


### PR DESCRIPTION
Add monitoring support for astro, usage:

```
// Layout.astro
---
import Monitoring from 'react-scan/monitoring/astro'
---

<Monitoring apiKey="" url="https://monitoring.react-scan.com/api/v1/ingest"/>
```
