### PR TITLE
feat(scan): allow users to have toolbar mounted while enabled as false

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -59,6 +59,8 @@ export interface Options {
   /**
    * Show toolbar bar
    *
+   * If you set this to true, and set {@link enabled} to false, the toolbar will still show, but scanning will be disabled.
+   *
    * @default true
    */
   showToolbar?: boolean;
@@ -202,11 +204,12 @@ export const getReport = (type?: React.ComponentType<any>) => {
   return Store.legacyReportData;
 };
 
-export const  setOptions = (options: Options) => {
+export const setOptions = (options: Options) => {
   const { instrumentation } = ReactScanInternals;
   if (instrumentation) {
     instrumentation.isPaused.value = options.enabled === false;
   }
+
   ReactScanInternals.options.value = {
     ...ReactScanInternals.options.value,
     ...options,
@@ -355,7 +358,8 @@ export const withScan = <T>(
   setOptions(options);
   const isInIframe = Store.isInIframe.value;
   const componentAllowList = ReactScanInternals.componentAllowList;
-  if (isInIframe || options.enabled === false) return component;
+  if (isInIframe || (options.enabled === false && options.showToolbar !== true))
+    return component;
   if (!componentAllowList) {
     ReactScanInternals.componentAllowList = new WeakMap<
       React.ComponentType<any>,
@@ -374,12 +378,13 @@ export const withScan = <T>(
 export const scan = (options: Options = {}) => {
   setOptions(options);
   const isInIframe = Store.isInIframe.value;
-  if (isInIframe || options.enabled === false) return;
+  if (isInIframe || (options.enabled === false && options.showToolbar !== true))
+    return;
 
   start();
 };
 
-export const useScan = (options: Options={}) => {
+export const useScan = (options: Options = {}) => {
   setOptions(options);
   start();
 };

--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -11,6 +11,7 @@ import {
   getType,
 } from 'bippy';
 import { signal } from '@preact/signals';
+import { ReactScanInternals } from '.';
 
 export interface Change {
   name: string;
@@ -198,7 +199,7 @@ export const createInstrumentation = ({
   onCommitFinish: () => void;
 }) => {
   const instrumentation = {
-    isPaused: signal(false),
+    isPaused: signal(!ReactScanInternals.options.value.enabled), // this will typically be false, but in cases where a user provides showToolbar: true, this will be true
     fiberRoots: new Set<FiberRoot>(),
     onCommitFiberRoot: (_rendererID: number, _root: FiberRoot) => {
       /**/


### PR DESCRIPTION
Previously, there was no way to mount the toolbar while having the scanning turned off. Now, providing the config below will allow users to have scanning turned off by default, but still have the toolbar mounted, acting as an opt-in with the toolbar.

```typescript
scan({
  enabled: false,
  showToolbar: true
});
```
