### PR TITLE
fix(scan-core): enabling the sound toggle should not close the toolbar.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,8 +17,8 @@ pnpm run dev
 ## 3. Run test environment
 
 ```bash
-cd test
+cd packages/kitchen-sink
 pnpm run dev
 ```
 
-Go to http://localhost:5173 to see the test environment.
+Go to http://localhost:5175 to see the test environment.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,11 +14,6 @@ pnpm install
 pnpm run dev
 ```
 
-## 3. Run test environment
+## 3. Navigate to the test environment.
 
-```bash
-cd packages/kitchen-sink
-pnpm run dev
-```
-
-Go to http://localhost:5175 to see the test environment.
+Go to http://localhost:5173 to see the test environment.

--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -228,7 +228,7 @@ export const setOptions = (options: Options) => {
     ...options,
   };
 
-  if (previousOptions.showToolbar && !options.showToolbar) {
+  if (previousOptions.showToolbar && options.showToolbar === false) {
     if (toolbarContainer) {
       toolbarContainer.remove();
       toolbarContainer = null;


### PR DESCRIPTION
## context

The audio toggle was causing the toolbar to be closed since there was check that was returning true whenever `options.showToolbar` was falsy. 

## changes
* explicitly check `options.showToolbar === false` when determining if the toolbar should be removed.
* update the docs for testing
* add a comment to the `playGeigerClickSound` function about why audio does not work in Firefox