### PR TITLE
fix: move toolbar root container to createToolbar

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -68,15 +68,10 @@ const initRootContainer = (): RootContainer => {
     ICONS,
     'image/svg+xml',
   ).documentElement;
-  shadowRoot.appendChild(iconSprite);
 
-  const root = document.createElement('div');
-  root.id = 'react-scan-toolbar-root';
-  root.className = 'absolute z-2147483647';
 
+  fragment.appendChild(iconSprite);
   fragment.appendChild(cssStyles);
-  fragment.appendChild(root);
-
   shadowRoot.appendChild(fragment);
 
   document.documentElement.appendChild(rootContainer);

--- a/packages/scan/src/web/assets/css/styles.tailwind.css
+++ b/packages/scan/src/web/assets/css/styles.tailwind.css
@@ -94,13 +94,13 @@ svg {
 }
 
 .button {
-	&:hover {
-		background: rgba(255, 255, 255, 0.1);
-	}
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
 
-	&:active {
-		background: rgba(255, 255, 255, 0.15);
-	}
+  &:active {
+    background: rgba(255, 255, 255, 0.15);
+  }
 }
 
 .resize-line-wrapper {
@@ -312,8 +312,8 @@ svg {
 }
 
 @keyframes blink {
-	from { opacity: 1; }
-	to { opacity: 0; }
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 .react-scan-arrow {

--- a/packages/scan/src/web/toolbar.tsx
+++ b/packages/scan/src/web/toolbar.tsx
@@ -44,6 +44,7 @@ class ToolbarErrorBoundary extends Component {
 
 export const createToolbar = (root: ShadowRoot): HTMLElement => {
   const container = document.createElement('div');
+  container.id = 'react-scan-toolbar-root';
   window.__REACT_SCAN_TOOLBAR_CONTAINER__ = container;
   scriptLevelToolbar = container
   root.appendChild(container);


### PR DESCRIPTION
- Remove redundant DOM nesting in shadow root
- Move container ID assignment to createToolbar
- Fix fragment elements order for better initialization