### PR TITLE
fix: toolbar position issue when the direction is rtl

### DIFF
--- a/packages/scan/src/web/components/inspector/overlay/index.tsx
+++ b/packages/scan/src/web/components/inspector/overlay/index.tsx
@@ -728,6 +728,7 @@ export const ScanOverlay = () => {
       />
       <canvas
         ref={refCanvas}
+        dir="ltr"
         className={cn(
           'react-scan-inspector-overlay',
           'fixed inset-0 w-screen h-screen',

--- a/packages/scan/src/web/components/widget/index.tsx
+++ b/packages/scan/src/web/components/widget/index.tsx
@@ -253,6 +253,8 @@ export const Widget = () => {
   useEffect(() => {
     if (!refWidget.current) return;
 
+    refWidget.current.dir = 'ltr';
+    refWidget.current.style.placeSelf = 'self-start';
     refWidget.current.style.width = 'min-content';
     refInitialMinimizedHeight.current = 36; // height of the header
     refInitialMinimizedWidth.current = refWidget.current.offsetWidth;


### PR DESCRIPTION
To fix #190 

### Changes ###
- enforcing `ltr` on the widget so the layout stays the same in `rtl`
- enforcing `ltr` on the canvas so the text doesn't go out of the pill in `rtl`
- align the widget with the inline direction using `place-self`

some known limitations
- safari doesn't support [place-self](https://developer.mozilla.org/en-US/docs/Web/CSS/place-self#browser_compatibility) or [justify-self](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self#browser_compatibility) yet
- it doesn't fix the issue where the rect in canvas shifts slightly to the left in `rtl` (as seen in the videos below when it highlights an element). I don't have a good solution to this yet, I believe it is the scrollbar width

### Example ###

**Before**

https://github.com/user-attachments/assets/6b1ce4a0-5604-475e-899a-fe8126f523bc

**After**

https://github.com/user-attachments/assets/56f72d4a-4c10-43f2-ae21-eb1df82066c1




