### PR TITLE
fix: year updated to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Aiden Bai, Million Software, Inc.
+Copyright 2025 Aiden Bai, Million Software, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/scan/src/web/utils/geiger.ts
+++ b/packages/scan/src/web/utils/geiger.ts
@@ -1,5 +1,5 @@
 // MIT License
-// Copyright (c) 2024 Kristian Dupont
+// Copyright (c) 2025 Kristian Dupont
 
 import { isFirefox, readLocalStorage } from './helpers';
 

--- a/packages/scan/tsup.config.ts
+++ b/packages/scan/tsup.config.ts
@@ -26,7 +26,7 @@ const addDirectivesToChunkFiles = async (readPath: string): Promise<void> => {
 };
 
 const banner = `/**
- * Copyright 2024 Aiden Bai, Million Software, Inc.
+ * Copyright 2025 Aiden Bai, Million Software, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
  * and associated documentation files (the “Software”), to deal in the Software without restriction,

--- a/packages/vite-plugin-react-scan/LICENSE
+++ b/packages/vite-plugin-react-scan/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Aiden Bai, Million Software, Inc.
+Copyright 2025 Aiden Bai, Million Software, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/website/components/footer.tsx
+++ b/packages/website/components/footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
           <div>© {new Date().getFullYear()} Million Software, Inc.</div>
         </div>
         <div>
-          {' '}
+          {" "}
           <a
             className="underline"
             href="https://github.com/aidenybai/react-scan"


### PR DESCRIPTION
This PR updates the year from 2024 to 2025 in the footer and other docs 

<img width="680" alt="image" src="https://github.com/user-attachments/assets/ec288044-c94e-4701-9425-c8c482231407" />
