### PR TITLE
feat: replace mouse events with pointer events for toolbar drag and drop on mobile

### DIFF
--- a/packages/scan/src/web/components/slider/index.tsx
+++ b/packages/scan/src/web/components/slider/index.tsx
@@ -56,7 +56,7 @@ export const Slider = ({
 
   return (
     <div
-      onMouseDown={(e) => {
+      onPointerDown={(e) => {
         e.stopPropagation();
       }}
       className={cn(

--- a/packages/scan/src/web/views/inspector/components-tree/index.tsx
+++ b/packages/scan/src/web/views/inspector/components-tree/index.tsx
@@ -712,7 +712,7 @@ export const ComponentsTree = () => {
 
       updateResizeDirection(startWidth);
 
-      const handleMouseMove = (e: MouseEvent) => {
+      const handlePointerMove = (e: PointerEvent) => {
         const delta = startX - e.clientX;
         const newWidth = startWidth + delta;
         updateResizeDirection(newWidth);
@@ -724,11 +724,11 @@ export const ComponentsTree = () => {
         updateContainerWidths(clampedWidth);
       };
 
-      const handleMouseUp = () => {
+      const handlePointerUp = () => {
         if (!refContainer.current) return;
         refContainer.current.style.removeProperty('pointer-events');
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
 
         signalWidget.value = {
           ...signalWidget.value,
@@ -742,8 +742,8 @@ export const ComponentsTree = () => {
         refIsResizing.current = false;
       };
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
     },
     [updateContainerWidths, updateResizeDirection],
   );
@@ -759,7 +759,7 @@ export const ComponentsTree = () => {
     });
   }, [updateResizeDirection]);
 
-  const onMouseLeave = useCallback(() => {
+  const onPointerLeave = useCallback(() => {
     refIsHovering.current = false;
   }, []);
 
@@ -970,7 +970,7 @@ export const ComponentsTree = () => {
     <div className="react-scan-components-tree flex">
       <div
         ref={refResizeHandle}
-        onMouseDown={handleResize}
+        onPointerDown={handleResize}
         className="relative resize-v-line"
       >
         <span>
@@ -1023,7 +1023,7 @@ export const ComponentsTree = () => {
                   e.stopPropagation();
                   e.currentTarget.focus();
                 }}
-                onMouseDown={(e) => {
+                onPointerDown={(e) => {
                   e.stopPropagation();
                 }}
                 onKeyDown={(e) => {
@@ -1117,7 +1117,7 @@ export const ComponentsTree = () => {
         <div className="flex-1 overflow-hidden">
           <div
             ref={refContainer}
-            onMouseLeave={onMouseLeave}
+            onPointerLeave={onPointerLeave}
             className="tree h-full overflow-auto will-change-transform"
           >
             <div

--- a/packages/scan/src/web/views/inspector/overlay/index.tsx
+++ b/packages/scan/src/web/views/inspector/overlay/index.tsx
@@ -372,7 +372,7 @@ export const ScanOverlay = () => {
     startFadeOut();
   };
 
-  const handleMouseMove = throttle((e?: MouseEvent) => {
+  const handlePointerMove = throttle((e?: PointerEvent) => {
     const state = Store.inspectState.peek();
     if (state.kind !== 'inspecting' || !refEventCatcher.current) return;
 
@@ -673,7 +673,7 @@ export const ScanOverlay = () => {
 
     window.addEventListener('scroll', handleResizeOrScroll, { passive: true });
     window.addEventListener('resize', handleResizeOrScroll, { passive: true });
-    document.addEventListener('mousemove', handleMouseMove, {
+    document.addEventListener('pointermove', handlePointerMove, {
       passive: true,
       capture: true,
     });
@@ -688,7 +688,7 @@ export const ScanOverlay = () => {
       unSubState();
       window.removeEventListener('scroll', handleResizeOrScroll);
       window.removeEventListener('resize', handleResizeOrScroll);
-      document.removeEventListener('mousemove', handleMouseMove, {
+      document.removeEventListener('pointermove', handlePointerMove, {
         capture: true,
       });
       document.removeEventListener('click', handleClick, { capture: true });

--- a/packages/scan/src/web/widget/resize-handle.tsx
+++ b/packages/scan/src/web/widget/resize-handle.tsx
@@ -115,7 +115,7 @@ export const ResizeHandle = ({ position }: ResizeHandleProps) => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: no deps
   const handleResize = useCallback(
-    (e: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+    (e: JSX.TargetedPointerEvent<HTMLDivElement>) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -145,7 +145,7 @@ export const ResizeHandle = ({ position }: ResizeHandleProps) => {
 
       let rafId: number | null = null;
 
-      const handleMouseMove = (e: MouseEvent) => {
+      const handlePointerMove = (e: PointerEvent) => {
         if (rafId) return;
 
         containerStyle.transition = 'none';
@@ -190,13 +190,13 @@ export const ResizeHandle = ({ position }: ResizeHandleProps) => {
         });
       };
 
-      const handleMouseUp = () => {
+      const handlePointerUp = () => {
         if (rafId) {
           cancelAnimationFrame(rafId);
           rafId = null;
         }
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
 
         const { dimensions, corner } = signalWidget.value;
         const windowDims = getWindowDimensions();
@@ -249,10 +249,10 @@ export const ResizeHandle = ({ position }: ResizeHandleProps) => {
         });
       };
 
-      document.addEventListener('mousemove', handleMouseMove, {
+      document.addEventListener('pointermove', handlePointerMove, {
         passive: true,
       });
-      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('pointerup', handlePointerUp);
     },
     [],
   );
@@ -366,7 +366,7 @@ export const ResizeHandle = ({ position }: ResizeHandleProps) => {
   return (
     <div
       ref={refContainer}
-      onMouseDown={handleResize}
+      onPointerDown={handleResize}
       onDblClick={handleDoubleClick}
       className={cn(
         'absolute z-50',


### PR DESCRIPTION
This pull request refactors the toolbar's drag and drop functionality by replacing mouse events with pointer events. This change is primarily focused on improving the drag and drop behavior on mobile devices, where pointer events provide better support for touch interactions.

### Key Changes:

- Replaced `mousedown`, `mousemove`, and `mouseup` events with `pointerdown`, `pointermove`, and `pointerup` to ensure smoother touch interactions on mobile.

- The new event handling allows for consistent behavior across both mouse and touch inputs, enhancing the overall user experience on mobile devices.

### Why This Change is Necessary:
- Mobile devices often have issues with mouse events, especially when it comes to touch interactions, so using pointer events ensures better compatibility and responsiveness.
- This refactor ensures that the drag and drop functionality works seamlessly across all devices, whether using a mouse or touch input.


# Before 

https://github.com/user-attachments/assets/ae87784c-80a8-4c37-8223-2cc177b83795



# After

https://github.com/user-attachments/assets/f1156d11-6d38-47e3-a6e3-677d5cc1d68e

