### PR TITLE
feat: show rendered parents in notifications view

### DIFF
--- a/packages/scan/src/core/notifications/event-tracking.ts
+++ b/packages/scan/src/core/notifications/event-tracking.ts
@@ -288,6 +288,9 @@ export const startDirtyTaskTracking = () => {
   };
 };
 
+
+export const HIGH_SEVERITY_FPS_DROP_TIME = 150
+
 let framesDrawnInTheLastSecond: Array<number> = [];
 
 export function startLongPipelineTracking() {
@@ -322,7 +325,7 @@ export function startLongPipelineTracking() {
             : null;
 
 
-        if (duration > 100 && !taskConsideredDirty) {
+        if (duration > HIGH_SEVERITY_FPS_DROP_TIME && !taskConsideredDirty) {
           const endAt = endOrigin + endNow;
           const startAt = startTime + startOrigin;
 

--- a/packages/scan/src/core/notifications/performance.ts
+++ b/packages/scan/src/core/notifications/performance.ts
@@ -878,9 +878,8 @@ export const listenForRenders = (
     const existing = fiberRenders[displayName];
     if (!existing) {
       const parents = new Set<string>();
-      const parentCompositeName = getDisplayName(
-        getParentCompositeFiber(fiber),
-      );
+      const res = fiber.return && getParentCompositeFiber(fiber.return);
+      const parentCompositeName = res && getDisplayName(res[0]);
       if (parentCompositeName) {
         parents.add(parentCompositeName);
       }
@@ -916,7 +915,8 @@ export const listenForRenders = (
     }
     const parentType = getParentCompositeFiber(fiber)?.[0]?.type;
     if (parentType) {
-      const parentCompositeName = getDisplayName(parentType);
+      const res = fiber.return && getParentCompositeFiber(fiber.return);
+      const parentCompositeName = res && getDisplayName(res[0]);
       if (parentCompositeName) {
         existing.parents.add(parentCompositeName);
       }

--- a/packages/scan/src/web/views/notifications/data.ts
+++ b/packages/scan/src/web/views/notifications/data.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'preact';
 import { SetStateAction } from 'preact/compat';
 import { Dispatch, useContext } from 'preact/hooks';
+import { HIGH_SEVERITY_FPS_DROP_TIME } from '~core/notifications/event-tracking';
 
 export type GroupedFiberRender = {
   id: string;
@@ -16,6 +17,7 @@ export type GroupedFiberRender = {
   totalTime: number;
   elements: Array<Element>; // can't do a weak set because need to iterate over them......
   deletedAll: boolean;
+  parents: Set<string>;
 };
 export const getComponentName = (path: Array<string>) => {
   const filteredPath = path.filter((item) => item.length > 2);
@@ -167,7 +169,7 @@ export const getEventSeverity = (event: NotificationEvent) => {
     }
     case 'dropped-frames': {
       if (totalTime < 50) return 'low';
-      if (totalTime < 100) return 'needs-improvement';
+      if (totalTime < HIGH_SEVERITY_FPS_DROP_TIME) return 'needs-improvement';
       return 'high';
     }
   }

--- a/packages/scan/src/web/views/notifications/notifications.tsx
+++ b/packages/scan/src/web/views/notifications/notifications.tsx
@@ -25,6 +25,7 @@ const getGroupedFiberRenders = (fiberRenders: FiberRenders) => {
     count: render.nodeInfo.length,
     name: render.nodeInfo[0].name, // invariant, at least one exists,
     deletedAll: false,
+    parents: render.parents,
     // it would be nice if we calculated the % of components memoizable, but this would have to be calculated downstream before it got aggregated
     elements: render.nodeInfo.map((node) => node.element),
     changes: {

--- a/packages/scan/src/web/views/notifications/render-bar-chart.tsx
+++ b/packages/scan/src/web/views/notifications/render-bar-chart.tsx
@@ -4,6 +4,7 @@ import { getIsProduction } from '~core/index';
 import { iife } from '~core/notifications/performance-utils';
 import { cn } from '~web/utils/helpers';
 import {
+  GroupedFiberRender,
   NotificationEvent,
   getTotalTime,
   isRenderMemoizable,
@@ -13,6 +14,7 @@ import {
   HighlightStore,
   drawHighlights,
 } from '~core/notifications/outline-overlay';
+import { ChevronRight } from './icons';
 
 // todo: cleanup, convoluted ternaries
 export const fadeOutHighlights = () => {
@@ -48,20 +50,21 @@ export const fadeOutHighlights = () => {
   };
 };
 
+type Bars = Array<
+  | { kind: 'other-frame-drop'; totalTime: number }
+  | { kind: 'other-not-javascript'; totalTime: number }
+  | { kind: 'other-javascript'; totalTime: number }
+  | { kind: 'render'; event: GroupedFiberRender; totalTime: number }
+>;
+
 export const RenderBarChart = ({
   selectedEvent,
 }: { selectedEvent: NotificationEvent }) => {
-  const { setNotificationState, setRoute } = useNotificationsContext();
   const totalInteractionTime = getTotalTime(selectedEvent.timing);
   const nonRender = totalInteractionTime - selectedEvent.timing.renderTime;
   const [isProduction] = useState(getIsProduction());
   const events = selectedEvent.groupedFiberRenders;
-  const bars: Array<
-    | { kind: 'other-frame-drop'; totalTime: number }
-    | { kind: 'other-not-javascript'; totalTime: number }
-    | { kind: 'other-javascript'; totalTime: number }
-    | { kind: 'render'; event: (typeof events)[number]; totalTime: number }
-  > = events.map((event) => ({
+  const bars: Bars = events.map((event) => ({
     event,
     kind: 'render',
     totalTime: isProduction ? event.count : event.totalTime,
@@ -119,12 +122,7 @@ export const RenderBarChart = ({
   const totalBarTime = bars.reduce((prev, curr) => prev + curr.totalTime, 0);
 
   return (
-    <div
-      onMouseLeave={() => {
-        fadeOutHighlights();
-      }}
-      className={cn(['flex flex-col h-full w-full gap-y-1'])}
-    >
+    <div className={cn(['flex flex-col h-full w-full gap-y-1'])}>
       {iife(() => {
         if (isProduction && bars.length === 0) {
           return (
@@ -154,261 +152,14 @@ export const RenderBarChart = ({
 
       {bars
         .toSorted((a, b) => b.totalTime - a.totalTime)
-        .map((bar, index) => (
-          <button
-            onMouseLeave={() => {
-              debouncedMouseEnter.current.timer &&
-                clearTimeout(debouncedMouseEnter.current.timer);
-            }}
-            onMouseEnter={async () => {
-              const highlightBars = async () => {
-                debouncedMouseEnter.current.lastCallAt = Date.now();
-                if (bar.kind !== 'render') {
-                  // todo: generalize this, its duplicated in onMouseLeave of bar chart
-                  const curr = HighlightStore.value.current
-                    ? HighlightStore.value.current
-                    : HighlightStore.value.kind === 'transition'
-                      ? HighlightStore.value.transitionTo
-                      : null;
-
-                  if (!curr) {
-                    HighlightStore.value = {
-                      kind: 'idle',
-                      current: null,
-                    };
-                    return;
-                  }
-                  HighlightStore.value = {
-                    kind: 'move-out',
-                    current: {
-                      alpha: 0,
-                      ...curr,
-                    },
-                  };
-                  return;
-                }
-                const state = HighlightStore.value;
-                const currentState = iife(() => {
-                  switch (state.kind) {
-                    case 'transition': {
-                      // because we want to dynamically fade this one out starting from its alpha
-                      return state.transitionTo; // but this breaks cause then we aren't passing current around current which should stay ;
-                    }
-                    case 'idle':
-                    case 'move-out': {
-                      return state.current;
-                    }
-                  }
-                });
-                const stateRects: Array<DOMRect> = [];
-
-                if (state.kind === 'transition') {
-                  const transitionState = getTransitionState(state);
-                  iife(() => {
-                    switch (transitionState) {
-                      case 'fading-in': {
-                        HighlightStore.value = {
-                          kind: 'transition',
-                          current: state.transitionTo,
-                          transitionTo: {
-                            rects: stateRects,
-                            alpha: 0,
-                            name: bar.event.name,
-                          },
-                        };
-                        return;
-                      }
-                      case 'fading-out': {
-                        HighlightStore.value = {
-                          kind: 'transition',
-                          current: HighlightStore.value.current
-                            ? {
-                                alpha: 0,
-                                ...HighlightStore.value.current,
-                              }
-                            : null,
-                          transitionTo: {
-                            rects: stateRects,
-                            alpha: 0,
-                            name: bar.event.name,
-                          },
-                        };
-                        return;
-                      }
-                    }
-                  });
-                } else {
-                  HighlightStore.value = {
-                    kind: 'transition',
-                    transitionTo: {
-                      rects: stateRects,
-                      alpha: 0,
-                      name: bar.event.name,
-                    },
-                    current: currentState
-                      ? {
-                          alpha: 0,
-                          ...currentState,
-                        }
-                      : null,
-                  };
-                }
-
-                // we need to filter this at source this is just a hack to keep moving
-                const trueElements = bar.event.elements.filter(
-                  (element) => element instanceof Element,
-                );
-                // todo only draw onscreen rects, but make it clear there are rects off the screen, this needs to be uber clear shouldn't just not draw it that's sub optimal
-
-                for await (const entries of getBatchedRectMap(trueElements)) {
-                  // we draw the boundingClientRect instead of intersectionRect for better viability, as a trade off against aesthetics
-                  entries.forEach(({ boundingClientRect }) => {
-                    stateRects.push(boundingClientRect);
-                  });
-                  drawHighlights();
-                }
-              };
-
-              // we need to debounce this incase the user quickly scrolls/moves their mouse
-              // while getBatchedRectMap is async, the work still has to be done at some point, and it can get expensive
-              // and add overhead
-              if (
-                debouncedMouseEnter.current.lastCallAt &&
-                Date.now() - debouncedMouseEnter.current.lastCallAt < 200
-              ) {
-                debouncedMouseEnter.current.timer &&
-                  clearTimeout(debouncedMouseEnter.current.timer);
-                debouncedMouseEnter.current.timer = setTimeout(() => {
-                  highlightBars();
-                }, 200);
-                return;
-              }
-
-              highlightBars();
-            }}
-            onClick={() => {
-              switch (bar.kind) {
-                case 'render': {
-                  setNotificationState((prev) => ({
-                    ...prev,
-                    selectedFiber: bar.event,
-                  }));
-
-                  setRoute({
-                    route: 'render-explanation',
-                    routeMessage: null,
-                  });
-                  return;
-                }
-                case 'other-not-javascript':
-                case 'other-javascript':
-                case 'other-frame-drop': {
-                  setRoute({
-                    route: 'other-visualization',
-                    routeMessage: {
-                      kind: 'auto-open-overview-accordion',
-                      name: bar.kind,
-                    },
-                  });
-                  return;
-                }
-              }
-            }}
-            // THIS IS ON PURPOSE, WE USE INDEX AS EQUALITY OF ANIMATION, THIS WILL NOT REORDER AND DOESN'T HOLD INTERNAL STATE, IF IT DID, IT MAY CREATE A BUG
-            key={index}
-            className={cn([
-              'w-full flex items-center group hover:bg-[#0f0f0f] rounded-md relative transition-colors text-xs',
-            ])}
-          >
-            <div className={cn(['h-full w-[90%]'])}>
-              <div
-                style={{
-                  minWidth: 'fit-content',
-                  width: `${(bar.totalTime / totalBarTime) * 100}%`,
-                }}
-                className={cn([
-                  'flex items-center  rounded-sm text-white text-xs relative h-[28px] transition-all',
-                  bar.kind === 'render' &&
-                    'bg-[#412162] group-hover:bg-[#5b2d89]',
-                  bar.kind === 'other-frame-drop' &&
-                    'bg-[#44444a] group-hover:bg-[#6a6a6a]',
-                  bar.kind === 'other-javascript' &&
-                    'bg-[#efd81a6b] group-hover:bg-[#efda1a2f]',
-                  bar.kind === 'other-not-javascript' &&
-                    'bg-[#214379d4] group-hover:bg-[#21437982]',
-                ])}
-              >
-                <div
-                  className={cn([
-                    'absolute left-2 top-1/2 -translate-y-1/2 flex gap-x-2',
-                  ])}
-                >
-                  <span className={cn(['flex items-center whitespace-nowrap'])}>
-                    {iife(() => {
-                      switch (bar.kind) {
-                        case 'other-frame-drop': {
-                          return 'JavaScript, DOM updates, Draw Frame';
-                        }
-                        case 'other-javascript': {
-                          return 'JavaScript/React Hooks';
-                        }
-                        case 'other-not-javascript': {
-                          return 'Update DOM and Draw New Frame';
-                        }
-                        case 'render': {
-                          return bar.event.name;
-                        }
-                      }
-                    })}
-                  </span>
-                  {bar.kind === 'render' && isRenderMemoizable(bar.event) && (
-                    <div
-                      style={{
-                        lineHeight: '10px',
-                      }}
-                      className={cn([
-                        'px-1 py-0.5 bg-[#6a369e] flex items-center  rounded-sm font-semibold text-[8px] w-fit',
-                      ])}
-                    >
-                      Memoizable
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div
-              className={cn([
-                'w-[5%] min-w-fit h-full flex items-center justify-end text-[10px] pr-1 gap-x-1',
-              ])}
-            >
-              {bar.kind === 'render' && (
-                <span className={cn([''])}>x{bar.event.count}</span>
-              )}
-            </div>
-            {/* we don't have render times in production, so we just visualize the count (impl is hacky) */}
-            {(bar.kind !== 'render' || !isProduction) && (
-              <div
-                className={cn([
-                  'w-[5%] min-w-fit text-[#7346a0] h-full flex items-center justify-end text-[10px] pr-1 gap-x-1',
-                ])}
-              >
-                <span>
-                  {bar.totalTime < 1 ? '<1' : bar.totalTime.toFixed(0)}
-                  ms
-                </span>
-              </div>
-            )}
-
-            <div
-              className={cn([
-                'absolute right-0 top-1/2 transition-none  -translate-y-1/2 bg-white text-black px-2 py-1 rounded text-xs opacity-0 group-hover:opacity-100 transition-opacity mr-16',
-                'pointer-events-none',
-              ])}
-            >
-              Click to learn more
-            </div>
-          </button>
+        .map((bar) => (
+          <RenderBar
+            bars={bars}
+            bar={bar}
+            debouncedMouseEnter={debouncedMouseEnter}
+            totalBarTime={totalBarTime}
+            isProduction={isProduction}
+          />
         ))}
     </div>
   );
@@ -425,4 +176,344 @@ const getTransitionState = (state: {
     return 'fading-out' as const;
   }
   return 'fading-in' as const;
+};
+
+const RenderBar = ({
+  bar,
+  debouncedMouseEnter,
+  totalBarTime,
+  isProduction,
+  bars,
+  depth = 0,
+}: {
+  depth?: number;
+  bars: Bars;
+  bar: Bars[number];
+  debouncedMouseEnter: {
+    current: {
+      timer: ReturnType<typeof setTimeout> | null;
+      lastCallAt: number | null;
+    };
+  };
+  totalBarTime: number;
+  isProduction: boolean | null;
+}) => {
+  const { setNotificationState, setRoute } = useNotificationsContext();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isLeaf = bar.kind === 'render' ? bar.event.parents.size === 0 : true;
+
+  const parentBars = bars.filter((otherBar) =>
+    otherBar.kind === 'render' && bar.kind === 'render'
+      ? bar.event.parents.has(otherBar.event.name) &&
+        otherBar.event.name !== bar.event.name
+      : false,
+  );
+
+  const missingParentNames =
+    bar.kind === 'render'
+      ? Array.from(bar.event.parents).filter(
+          (parentName) =>
+            !bars.some(
+              (b) => b.kind === 'render' && b.event.name === parentName,
+            ),
+        )
+      : [];
+
+  const handleBarClick = () => {
+    if (bar.kind === 'render') {
+      setNotificationState((prev) => ({
+        ...prev,
+        selectedFiber: bar.event,
+      }));
+
+      setRoute({
+        route: 'render-explanation',
+        routeMessage: null,
+      });
+    } else {
+      setRoute({
+        route: 'other-visualization',
+        routeMessage: {
+          kind: 'auto-open-overview-accordion',
+          name: bar.kind,
+        },
+      });
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div
+        className={cn(['w-full flex items-center relative text-xs min-w-0'])}
+      >
+        <button
+          onMouseLeave={() => {
+            debouncedMouseEnter.current.timer &&
+              clearTimeout(debouncedMouseEnter.current.timer);
+            fadeOutHighlights();
+          }}
+          onMouseEnter={async () => {
+            const highlightBars = async () => {
+              debouncedMouseEnter.current.lastCallAt = Date.now();
+              if (bar.kind !== 'render') {
+                const curr = HighlightStore.value.current
+                  ? HighlightStore.value.current
+                  : HighlightStore.value.kind === 'transition'
+                    ? HighlightStore.value.transitionTo
+                    : null;
+
+                if (!curr) {
+                  HighlightStore.value = {
+                    kind: 'idle',
+                    current: null,
+                  };
+                  return;
+                }
+                HighlightStore.value = {
+                  kind: 'move-out',
+                  current: {
+                    alpha: 0,
+                    ...curr,
+                  },
+                };
+                return;
+              }
+              const state = HighlightStore.value;
+              const currentState = iife(() => {
+                switch (state.kind) {
+                  case 'transition': {
+                    return state.transitionTo;
+                  }
+                  case 'idle':
+                  case 'move-out': {
+                    return state.current;
+                  }
+                }
+              });
+              const stateRects: Array<DOMRect> = [];
+
+              if (state.kind === 'transition') {
+                const transitionState = getTransitionState(state);
+                iife(() => {
+                  switch (transitionState) {
+                    case 'fading-in': {
+                      HighlightStore.value = {
+                        kind: 'transition',
+                        current: state.transitionTo,
+                        transitionTo: {
+                          rects: stateRects,
+                          alpha: 0,
+                          name: bar.event.name,
+                        },
+                      };
+                      return;
+                    }
+                    case 'fading-out': {
+                      HighlightStore.value = {
+                        kind: 'transition',
+                        current: HighlightStore.value.current
+                          ? {
+                              alpha: 0,
+                              ...HighlightStore.value.current,
+                            }
+                          : null,
+                        transitionTo: {
+                          rects: stateRects,
+                          alpha: 0,
+                          name: bar.event.name,
+                        },
+                      };
+                      return;
+                    }
+                  }
+                });
+              } else {
+                HighlightStore.value = {
+                  kind: 'transition',
+                  transitionTo: {
+                    rects: stateRects,
+                    alpha: 0,
+                    name: bar.event.name,
+                  },
+                  current: currentState
+                    ? {
+                        alpha: 0,
+                        ...currentState,
+                      }
+                    : null,
+                };
+              }
+
+              const trueElements = bar.event.elements.filter(
+                (element) => element instanceof Element,
+              );
+
+              for await (const entries of getBatchedRectMap(trueElements)) {
+                entries.forEach(({ boundingClientRect }) => {
+                  stateRects.push(boundingClientRect);
+                });
+                drawHighlights();
+              }
+            };
+
+            if (
+              debouncedMouseEnter.current.lastCallAt &&
+              Date.now() - debouncedMouseEnter.current.lastCallAt < 200
+            ) {
+              debouncedMouseEnter.current.timer &&
+                clearTimeout(debouncedMouseEnter.current.timer);
+              debouncedMouseEnter.current.timer = setTimeout(() => {
+                highlightBars();
+              }, 200);
+              return;
+            }
+
+            highlightBars();
+          }}
+          onClick={handleBarClick}
+          className={cn([
+            'h-full w-[90%] flex items-center hover:bg-[#0f0f0f] rounded-l-md min-w-0 relative',
+          ])}
+        >
+          <div
+            style={{
+              minWidth: 'fit-content',
+              width: `${(bar.totalTime / totalBarTime) * 100}%`,
+            }}
+            className={cn([
+              'flex items-center rounded-sm text-white text-xs h-[28px] shrink-0',
+              bar.kind === 'render' && 'bg-[#412162] group-hover:bg-[#5b2d89]',
+              bar.kind === 'other-frame-drop' &&
+                'bg-[#44444a] group-hover:bg-[#6a6a6a]',
+              bar.kind === 'other-javascript' &&
+                'bg-[#efd81a6b] group-hover:bg-[#efda1a2f]',
+              bar.kind === 'other-not-javascript' &&
+                'bg-[#214379d4] group-hover:bg-[#21437982]',
+            ])}
+          />
+          <div
+            className={cn([
+              'absolute inset-0 flex items-center px-2',
+              'min-w-0',
+            ])}
+          >
+            <div className="flex items-center gap-x-2 min-w-0 w-full">
+              <span className={cn(['truncate'])}>
+                {iife(() => {
+                  switch (bar.kind) {
+                    case 'other-frame-drop': {
+                      return 'JavaScript, DOM updates, Draw Frame';
+                    }
+                    case 'other-javascript': {
+                      return 'JavaScript/React Hooks';
+                    }
+                    case 'other-not-javascript': {
+                      return 'Update DOM and Draw New Frame';
+                    }
+                    case 'render': {
+                      return bar.event.name;
+                    }
+                  }
+                })}
+              </span>
+              {bar.kind === 'render' && isRenderMemoizable(bar.event) && (
+                <div
+                  style={{
+                    lineHeight: '10px',
+                  }}
+                  className={cn([
+                    'px-1 py-0.5 bg-[#6a369e] flex items-center rounded-sm font-semibold text-[8px] shrink-0',
+                  ])}
+                >
+                  Memoizable
+                </div>
+              )}
+            </div>
+          </div>
+        </button>
+
+        <button
+          onClick={() =>
+            bar.kind === 'render' && !isLeaf && setIsExpanded(!isExpanded)
+          }
+          className={cn([
+            'flex items-center min-w-fit shrink-0 hover:bg-[#0f0f0f] rounded-r-md h-[28px]',
+            bar.kind === 'render' && !isLeaf
+              ? 'cursor-pointer'
+              : 'cursor-default',
+          ])}
+        >
+          <div className="w-[20px] flex items-center justify-center">
+            {bar.kind === 'render' && !isLeaf && (
+              <ChevronRight
+                className={cn(
+                  'transition-transform',
+                  isExpanded && 'rotate-90',
+                )}
+                size={16}
+              />
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-x-1 min-w-[60px]">
+            {bar.kind === 'render' && (
+              <span className={cn(['text-[10px]'])}>x{bar.event.count}</span>
+            )}
+
+            {(bar.kind !== 'render' || !isProduction) && (
+              <span className="text-[10px] text-[#7346a0] pr-1">
+                {bar.totalTime < 1 ? '<1' : bar.totalTime.toFixed(0)}
+                ms
+              </span>
+            )}
+          </div>
+        </button>
+
+        {depth === 0 && (
+          <div
+            className={cn([
+              'absolute right-0 top-1/2 transition-none -translate-y-1/2 bg-white text-black px-2 py-1 rounded text-xs opacity-0 group-hover:opacity-100 transition-opacity mr-16',
+              'pointer-events-none',
+            ])}
+          >
+            Click to learn more
+          </div>
+        )}
+      </div>
+
+      {isExpanded &&
+        (parentBars.length > 0 || missingParentNames.length > 0) && (
+          <div className="pl-3 flex flex-col gap-y-1 mt-1">
+            {parentBars
+              .toSorted((a, b) => b.totalTime - a.totalTime)
+              .map((parentBar, i) => (
+                <RenderBar
+                  depth={depth + 1}
+                  key={i}
+                  bar={parentBar}
+                  debouncedMouseEnter={debouncedMouseEnter}
+                  totalBarTime={totalBarTime}
+                  isProduction={isProduction}
+                  bars={bars}
+                />
+              ))}
+            {missingParentNames.map((parentName) => (
+              <div key={parentName} className="w-full">
+                <div className="w-full flex items-center relative text-xs">
+                  <div className="h-full w-full flex items-center relative">
+                    <div className="flex items-center rounded-sm text-white text-xs h-[28px] w-full" />
+                    <div className="absolute inset-0 flex items-center px-2">
+                      <span className="truncate whitespace-nowrap text-white/70 w-full">
+                        {parentName}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+    </div>
+  );
 };


### PR DESCRIPTION
Recursively shows the parents (that rendered) of notification render bars

This is a little tricky to implement perfectly (w.r.t UX) since it's trivial to create a cycle:
```html
<Div>
  <Button>
    <Div>
      <Button/>
    </Div>
  </Button>
</Div>
```

In this case Div is a parent of Button, and vice versa. So this tree would recurse forever in notifications. 

This a limit to how the fiber renders datastructure is aggregated. We group fibers that are created from the same component together, and just store the count. So we have no way to express how many layers this cyclical structure holds. We can only track that some Div's had a Button parent, and some Buttons had a Div parent

This actually is fine in most cases, and I could not think of a trivial way to represent this better, while allowing memory to scale O(1) w.r.t grouped fibers

Demo: https://x.com/milliondotjs/status/1900041985378914464