### PR TITLE
chore: correct wording in memoizable notification message

### DIFF
--- a/packages/scan/src/web/views/notifications/render-explanation.tsx
+++ b/packages/scan/src/web/views/notifications/render-explanation.tsx
@@ -120,7 +120,7 @@ export const RenderExplanation = ({
               No changes detected
             </div>
             <div className={cn(['px-3 pb-2 text-gray-400 text-xs'])}>
-              This component would not of rendered if it was memoized
+              This component would not have rendered if it was memoized
             </div>
           </div>
         </div>


### PR DESCRIPTION
Small correction to the wording: `would not of` to `would not have`

This has already been implemented in the open PR https://github.com/aidenybai/react-scan/pull/326 , however there's a spelling mistake in the filename `packages/website/components/installl-guide.tsx` that makes that PR try to include a copy of that file with the wrong name.

This PR fixes the spelling mistake without the the extra file.