### PR TITLE
fix: update fiber renderData for both function and object types

### DIFF
--- a/packages/scan/src/core/utils.ts
+++ b/packages/scan/src/core/utils.ts
@@ -169,7 +169,7 @@ export const getLabelText = (
 export const updateFiberRenderData = (fiber: Fiber, renders: Array<Render>) => {
   ReactScanInternals.options.value.onRender?.(fiber, renders);
   const type = getType(fiber.type) || fiber.type;
-  if (type && typeof type === 'function' && typeof type === 'object') {
+  if (type && (typeof type === 'function' || typeof type === 'object')) {
     const renderData = (type.renderData || {
       count: 0,
       time: 0,


### PR DESCRIPTION
This fixes a bad logic in the `updateFiberRenderData` util.