### PR TITLE
chore: early return traversal when unnecessary render found

### DIFF
--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -368,13 +368,13 @@ function isRenderUnnecessaryTraversal(
   _propsName: string,
   prevValue: unknown,
   nextValue: unknown,
-): void {
-  if (
-    !isEqual(prevValue, nextValue) &&
-    !isValueUnstable(prevValue, nextValue)
-  ) {
-    this.isRequiredChange = true;
-  }
+): boolean {
+  const isRquiredChange =
+    !isEqual(prevValue, nextValue) && !isValueUnstable(prevValue, nextValue);
+  this.isRequiredChange = isRquiredChange;
+  // no need to continue traversal if found a prop change necessary 
+  // returning true to tell bippy to stop traversing the props list
+  return isRquiredChange;
 }
 
 // FIXME: calculation is slow


### PR DESCRIPTION
For a rendered fiber, if one prop change found necessary, we can say the fiber render is necessary, and no need to check the rest props. This PR hanldes that so it early returns `traverseProps`