### PR TITLE
docs: add installation guide for Rsbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ yarn add react-scan
 - [React Router](https://github.com/aidenybai/react-scan/blob/main/docs/installation/react-router.md)
 - [Astro](https://github.com/aidenybai/react-scan/blob/main/docs/installation/astro.md)
 - [TanStack Start](https://github.com/aidenybai/react-scan/blob/main/docs/installation/tanstack-start.md)
+- [Rsbuild](https://github.com/aidenybai/react-scan/blob/main/docs/installation/rsbuild.md)
 
 ### CLI
 

--- a/docs/installation/rsbuild.md
+++ b/docs/installation/rsbuild.md
@@ -1,0 +1,59 @@
+# Rsbuild Guide
+
+## As a script tag
+
+If you are using Rsbuild's default HTML template, add the script tag via [html.tags](https://rsbuild.dev/config/html/tags).
+
+Refer to the [CDN Guide](https://github.com/aidenybai/react-scan/blob/main/docs/installation/cdn.md) for the available URLs.
+
+```ts
+// rsbuild.config.ts
+export default {
+  html: {
+    tags: [
+      {
+        tag: "script",
+        attrs: {
+          src: "https://cdn.jsdelivr.net/npm/react-scan/dist/auto.global.js",
+        },
+        append: false,
+      },
+    ],
+  },
+};
+```
+
+If you are using a custom HTML template, add the script tag to your template file.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/react-scan/dist/auto.global.js"></script>
+
+    <!-- rest of your scripts go under -->
+  </head>
+  <body>
+    <!-- ... -->
+  </body>
+</html>
+```
+
+## As a module import
+
+In your project entrypoint (e.g. `src/index`, `src/main`):
+
+```jsx
+// src/index.jsx
+
+// must be imported before React and React DOM
+import { scan } from "react-scan";
+import React from "react";
+
+scan({
+  enabled: true,
+});
+```
+
+> [!CAUTION]
+> React Scan must be imported before React (and other React renderers like React DOM) in your entire project, as it needs to hijack React DevTools before React gets to access it.


### PR DESCRIPTION
Added Rsbuild installation guide to help Rsbuild users use react-scan more easily.

Ref:

- Related issue: https://github.com/aidenybai/react-scan/issues/18
- Rsbuild is an Rspack-based build tool, see https://rsbuild.dev/