### PR TITLE
fix: add missing title attribute

### DIFF
--- a/packages/scan/src/web/views/notifications/notification-header.tsx
+++ b/packages/scan/src/web/views/notifications/notification-header.tsx
@@ -59,6 +59,7 @@ export const NotificationHeader = ({
                       view: 'none',
                     };
                   }}
+                  title="Close"
                 >
                   <CloseIcon size={18} className="text-[#6F6F78]" />
                 </button>

--- a/packages/scan/src/web/views/notifications/slowdown-history.tsx
+++ b/packages/scan/src/web/views/notifications/slowdown-history.tsx
@@ -372,6 +372,7 @@ export const SlowdownHistory = () => {
           triggerContent={
             <button
               className={cn(['hover:bg-[#18181B] rounded-full p-2'])}
+              title="Clear all events"
               onClick={() => {
                 toolbarEventStore.getState().actions.clear();
                 setNotificationState((prev) => ({

--- a/packages/scan/src/web/views/toolbar/index.tsx
+++ b/packages/scan/src/web/views/toolbar/index.tsx
@@ -151,6 +151,7 @@ export const Toolbar = constant(() => {
         <button
           type="button"
           id="react-scan-notifications"
+          title="Notifications"
           onClick={() => {
             if (Store.inspectState.value.kind !== 'inspect-off') {
               Store.inspectState.value = {
@@ -207,6 +208,7 @@ export const Toolbar = constant(() => {
         checked={!ReactScanInternals.instrumentation?.isPaused.value}
         onChange={onToggleActive}
         className="place-self-center"
+        title="Visualise component updates"
       />
 
       {/* todo add back showFPS*/}

--- a/packages/scan/src/web/views/toolbar/index.tsx
+++ b/packages/scan/src/web/views/toolbar/index.tsx
@@ -208,7 +208,7 @@ export const Toolbar = constant(() => {
         checked={!ReactScanInternals.instrumentation?.isPaused.value}
         onChange={onToggleActive}
         className="place-self-center"
-        title="Visualise component updates"
+        title="Outline Re-renders"
       />
 
       {/* todo add back showFPS*/}


### PR DESCRIPTION
Certain buttons that only has icons is missing the title attribute. This causes accessibility scanners, for instance Axe, to fail when having react-scan active on a webpage.

<img width="617" alt="image" src="https://github.com/user-attachments/assets/82212be6-6c11-4434-810c-edc723fd5051" />

This title adds the missing attributes that I could identify. If there are more, I'm happy to fix those as well.