### PR TITLE
fix: duplicate render count when one component is reused multiple times

### DIFF
--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -476,7 +476,6 @@ const trackRender = (
   hasDomMutations: boolean,
 ) => {
   const currentTimestamp = Date.now();
-
   const type = getType(fiber.type)
   const existingData = getRenderData(type, fiber);
 

--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -438,11 +438,34 @@ export interface OldRenderData {
 
 const RENDER_DEBOUNCE_MS = 16;
 
-export const renderDataMap = new Map<string, RenderData>();
+export const renderDataMap = new WeakMap<object, Map<string, RenderData>>();
 
-export function getRenderDataMapKey(fiber: Fiber) {
-  const typeName = String(fiber?.type);
-  return `${typeName}-${fiber?.key ?? ''}-${fiber?.index ?? ''}`;
+function getFiberIdentifier(fiber: Fiber) {
+  return `${fiber.key}::${fiber.index}`;
+}
+
+export function getRenderData(type: unknown, fiber: Fiber) {
+  const id = getFiberIdentifier(fiber);
+  const keyMap = renderDataMap.get(type as object);
+
+  if (keyMap) {
+    return keyMap.get(id);
+  }
+
+  return undefined;
+}
+
+export function setRenderData(fiber: Fiber, value: RenderData) {
+  const type = getType(fiber.type)
+  const id = getFiberIdentifier(fiber);
+  let keyMap = renderDataMap.get(type as object);
+  
+  if (!keyMap) {
+    keyMap = new Map();
+    renderDataMap.set(type as object, keyMap);
+  }
+
+  keyMap.set(id, value);
 }
 
 const trackRender = (
@@ -454,9 +477,8 @@ const trackRender = (
 ) => {
   const currentTimestamp = Date.now();
 
-  const renderKey = getRenderDataMapKey(fiber)
-
-  const existingData = renderDataMap.get(renderKey);
+  const type = getType(fiber.type)
+  const existingData = getRenderData(type, fiber);
 
   if (
     (hasChanges || hasDomMutations) &&
@@ -476,7 +498,7 @@ const trackRender = (
     renderData.totalTime = fiberTotalTime || 0;
     renderData.lastRenderTimestamp = currentTimestamp;
 
-    renderDataMap.set(renderKey, { ...renderData });
+    setRenderData(fiber, { ...renderData });
   }
 };
 

--- a/packages/scan/src/web/views/inspector/components-tree/index.tsx
+++ b/packages/scan/src/web/views/inspector/components-tree/index.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'preact/hooks';
 import { Store } from '~core/index';
-import { renderDataMap } from '~core/instrumentation';
+import { getRenderDataMapKey, renderDataMap } from '~core/instrumentation';
 import { Icon } from '~web/components/icon';
 import {
   LOCALSTORAGE_KEY,
@@ -43,8 +43,10 @@ const flattenTree = (
       ? getFiberPath(node.fiber)
       : `${parentPath}-${index}`;
 
+    const key = getRenderDataMapKey(node?.fiber)
+
     const renderData = node.fiber?.type
-      ? renderDataMap.get(node.fiber.type)
+      ? renderDataMap.get(key)
       : undefined;
 
     const flatNode: FlattenedNode = {

--- a/packages/scan/src/web/views/inspector/components-tree/index.tsx
+++ b/packages/scan/src/web/views/inspector/components-tree/index.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'preact/hooks';
 import { Store } from '~core/index';
-import { getRenderDataMapKey, renderDataMap } from '~core/instrumentation';
+import { getRenderData } from '~core/instrumentation';
 import { Icon } from '~web/components/icon';
 import {
   LOCALSTORAGE_KEY,
@@ -43,10 +43,8 @@ const flattenTree = (
       ? getFiberPath(node.fiber)
       : `${parentPath}-${index}`;
 
-    const key = getRenderDataMapKey(node?.fiber)
-
     const renderData = node.fiber?.type
-      ? renderDataMap.get(key)
+      ? getRenderData(node.fiber.type, node.fiber)
       : undefined;
 
     const flatNode: FlattenedNode = {


### PR DESCRIPTION
fix https://github.com/aidenybai/react-scan/issues/356

I was waiting for feedback from the team, but I think it's better to open a PR so everyone can have a look into the proposed solution :) Suggestions are welcome!

**[Root cause]**
I believe this is due to [renderDataMap](https://github.com/aidenybai/react-scan/blob/main/packages/scan/src/core/instrumentation.ts#L441) using the fiber's `type` (function / class associated to the fiber) as the key.
In the example from the issue, it doesn't work because both the fibers share the same `type` reference. Since they share the same key in the `renderDataMap`, hence both have the same value (renderCount). 
This issue also happens without the keys:
```
  <Toolbar toolbar={topToolbar} />
  <Toolbar toolbar={bottomToolbar} />
```

**[Proposed solution]**
My proposed solution is quite straightforward:
- Use a composite key with additional fiber attributes like `fiber.key` and `fiber.index`
- Instead of storing a `RenderData` object as the value, store a Map with the composite key and the `RenderData` as the value

This allows us to cross check with the key and index to identify the correct fiber

**[Result]**


https://github.com/user-attachments/assets/54fc64b1-e379-4671-94d2-52151a3ff9cd