### PR TITLE
fix: compatible with styled components

### DIFF
--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -10,6 +10,7 @@ import {
   SimpleMemoComponentTag,
   didFiberCommit,
   getDisplayName,
+  getFiberId,
   getMutatedHostFibers,
   getTimings,
   getType,
@@ -441,12 +442,12 @@ const RENDER_DEBOUNCE_MS = 16;
 export const renderDataMap = new WeakMap<object, Map<string, RenderData>>();
 
 function getFiberIdentifier(fiber: Fiber) {
-  return `${fiber.key}::${fiber.index}`;
+  return String(getFiberId(fiber));
 }
 
-export function getRenderData(type: unknown, fiber: Fiber) {
+export function getRenderData(fiber: Fiber) {
   const id = getFiberIdentifier(fiber);
-  const keyMap = renderDataMap.get(type as object);
+  const keyMap = renderDataMap.get(getType(fiber) as object);
 
   if (keyMap) {
     return keyMap.get(id);
@@ -476,8 +477,7 @@ const trackRender = (
   hasDomMutations: boolean,
 ) => {
   const currentTimestamp = Date.now();
-  const type = getType(fiber.type)
-  const existingData = getRenderData(type, fiber);
+  const existingData = getRenderData(fiber);
 
   if (
     (hasChanges || hasDomMutations) &&

--- a/packages/scan/src/web/views/inspector/components-tree/index.tsx
+++ b/packages/scan/src/web/views/inspector/components-tree/index.tsx
@@ -44,7 +44,7 @@ const flattenTree = (
       : `${parentPath}-${index}`;
 
     const renderData = node.fiber?.type
-      ? getRenderData(node.fiber.type, node.fiber)
+      ? getRenderData(node.fiber)
       : undefined;
 
     const flatNode: FlattenedNode = {


### PR DESCRIPTION
fix https://github.com/aidenybai/react-scan/issues/355

`@emotion/styled` and `styled-components` [call components with forwardRef](https://github.com/emotion-js/emotion/blob/cce67ec6b2fc94261028b4f4778aae8c3d6c5fd6/packages/react/src/context.tsx#L30-L47) when generating them. We weren’t retrieving the fiber type from ForwardRef correctly, as it has a different data structure compared to functional and host components

To fix it, we just need to make a one line change: use `getRenderData(getType(node?.fiber))` instead of `getRenderData(node?.fiber.type)`.

Also, I cleaned up the code a bit as I just found out that Bippy already provides [getFiberId](https://github.com/aidenybai/bippy/blob/main/packages/bippy/src/core.ts#L555-L575) to manage uniqueId for fibers, so we don't really need to implement our own fiber identifier.

Tested on the preview link https://wys52t.csb.app mentioned in https://github.com/aidenybai/react-scan/issues/355

https://github.com/user-attachments/assets/914b3334-35ce-423e-9e29-c08a2dd4c2dc

