### PR TITLE
fix: detect react root in extension

### DIFF
--- a/packages/extension/src/utils/helpers.ts
+++ b/packages/extension/src/utils/helpers.ts
@@ -19,6 +19,7 @@ interface ReactRootContainer {
       };
     };
   };
+  __reactContainer$?: unknown;
 }
 
 const ReactDetection = {
@@ -42,7 +43,8 @@ const ReactDetection = {
   reactMarkers: {
     root: '_reactRootContainer',
     fiber: '__reactFiber',
-    instance: '__reactInternalInstance$'
+    instance: '__reactInternalInstance$',
+    container: '__reactContainer$'
   }
 } as const;
 
@@ -77,7 +79,13 @@ export const hasReactFiber = (): boolean => {
     if (ReactDetection.reactMarkers.root in element) {
       const elementWithRoot = element as unknown as ReactRootContainer;
       const rootContainer = elementWithRoot._reactRootContainer;
-      return rootContainer?._internalRoot?.current?.child != null;
+
+      const hasLegacyRoot = rootContainer?._internalRoot?.current?.child != null;
+      const hasContainerRoot = Object.keys(elementWithRoot).some(key => 
+        key.startsWith(ReactDetection.reactMarkers.container)
+      );
+
+      return hasLegacyRoot || hasContainerRoot;
     }
 
     for (const key of props) {


### PR DESCRIPTION
## Fix React Detection in react-scan chrome extension

## Problem
The React detection logic was only checking for legacy root containers (`_reactRootContainer`) and missing container-based roots that use the `__reactContainer$` pattern. This caused React detection to fail in applications using container-based root structures.

## Changes
- Added detection for container-based roots by checking for properties that start with `__reactContainer$`