### PR TITLE
fix: Render explanation typo

### DIFF
--- a/packages/scan/src/web/views/notifications/render-explanation.tsx
+++ b/packages/scan/src/web/views/notifications/render-explanation.tsx
@@ -120,7 +120,7 @@ export const RenderExplanation = ({
               No changes detected
             </div>
             <div className={cn(['px-3 pb-2 text-gray-400 text-xs'])}>
-              This component would not of rendered if it was memoized
+              This component would not have rendered if it was memoized
             </div>
           </div>
         </div>


### PR DESCRIPTION
This typo appears in this component:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/da61ef41-d88f-4315-88d3-af61e9a62996" />
