### PR TITLE
[Temporary]: Allow react scan to run in prod w/ npm package

### DIFF
--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scan",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Scan your React app for renders",
   "keywords": ["react", "react-scan", "react scan", "render", "performance"],
   "homepage": "https://react-scan.million.dev",
@@ -70,14 +70,14 @@
     ".": {
       "production": {
         "import": {
-          "types": "./dist/rsc-shim.d.mts",
+          "types": "./dist/index.d.mts",
           "react-server": "./dist/rsc-shim.mjs",
-          "default": "./dist/rsc-shim.mjs"
+          "default": "./dist/index.mjs"
         },
         "require": {
-          "types": "./dist/rsc-shim.d.ts",
+          "types": "./dist/index.d.mts",
           "react-server": "./dist/rsc-shim.js",
-          "default": "./dist/rsc-shim.js"
+          "default": "./dist/index.mjs"
         }
       },
       "development": {

--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scan",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Scan your React app for renders",
   "keywords": ["react", "react-scan", "react scan", "render", "performance"],
   "homepage": "https://react-scan.million.dev",

--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -105,6 +105,11 @@
         }
       }
     },
+    "./all-environments": {
+      "types": "./dist/core/all-environments.d.ts",
+      "import": "./dist/core/all-environments.mjs",
+      "require": "./dist/core/all-environments.js"
+    },
     "./install-hook": {
       "types": "./dist/install-hook.d.ts",
       "import": "./dist/install-hook.mjs",

--- a/packages/scan/src/core/all-environments.ts
+++ b/packages/scan/src/core/all-environments.ts
@@ -1,0 +1,8 @@
+import { ReactScanInternals, scan as innerScan } from '.';
+
+export const scan = /*#__PURE__*/ (...params: Parameters<typeof innerScan>) => {
+  if (typeof window !== 'undefined') {
+    ReactScanInternals.runInAllEnvironments = true;
+    innerScan(...params);
+  }
+};

--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -238,6 +238,7 @@ export interface Internals {
   onRender: ((fiber: Fiber, renders: Array<Render>) => void) | null;
   Store: StoreType;
   version: string;
+  runInAllEnvironments: boolean;
 }
 
 export type FunctionalComponentStateChange = {
@@ -320,6 +321,7 @@ export const ReactScanInternals: Internals = {
     // smoothlyAnimateOutlines: true,
     // trackUnnecessaryRenders: false,
   }),
+  runInAllEnvironments: false,
   onRender: null,
   scheduledOutlines: new Map(),
   activeOutlines: new Map(),
@@ -544,6 +546,7 @@ export const start = () => {
     }
 
     if (
+      !ReactScanInternals.runInAllEnvironments &&
       getIsProduction() &&
       !ReactScanInternals.options.value.dangerouslyForceRunInProduction
     ) {
@@ -634,7 +637,11 @@ export const scan = (options: Options = {}) => {
   setOptions(options);
   const isInIframe = Store.isInIframe.value;
 
-  if (isInIframe && !ReactScanInternals.options.value.allowInIframe) {
+  if (
+    isInIframe &&
+    !ReactScanInternals.options.value.allowInIframe &&
+    !ReactScanInternals.runInAllEnvironments
+  ) {
     return;
   }
 

--- a/packages/scan/tsup.config.ts
+++ b/packages/scan/tsup.config.ts
@@ -59,8 +59,7 @@ void (async () => {
     names.push(exportItem.n);
   }
 
-  const createFn = (name: string) =>
-    `export let ${name}=()=>{console.error('Do not use ${name} directly in a Server Component module. It should only be used in a Client Component.');return undefined}`;
+  const createFn = (name: string) => `export let ${name}=()=>{}`;
   const createVar = (name: string) => `export let ${name}=undefined`;
 
   let script = '';
@@ -117,6 +116,7 @@ export default defineConfig([
     entry: [
       './src/index.ts',
       './src/install-hook.ts',
+      './src/core/all-environments.ts',
       './src/core/monitor/index.ts',
       './src/core/monitor/params/next.ts',
       './src/core/monitor/params/react-router-v5.ts',


### PR DESCRIPTION
Add a subpath export, `"all-environment"s`, which exports an identical `scan` function that allows react-scan to run in production

Fixes: #386 
Fixes #310 
Fixes #350 

Example usage:
```typescript
import {scan} from 'react-scan/all-environments'
scan() // <- works in production and dev
```