### PR TITLE
Fix: Incorrect reference to filetLocalStorageOptions

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -508,7 +508,7 @@ export const setOptions = (userOptions: Partial<Options>) => {
 
     saveLocalStorage<LocalStorageOptions>(
       'react-scan-options',
-      filetLocalStorageOptions(newOptions),
+      applyLocalStorageOptions(newOptions),
     );
 
     if (shouldInitToolbar) {


### PR DESCRIPTION
This PR fixes a bug introduced in [#397](https://github.com/aidenybai/react-scan/pull/397) (my previous pull request), where the function name was updated from filetLocalStorageOptions to applyLocalStorageOptions, but the reference to the old name was not updated.

As a result, calling filetLocalStorageOptions causes a runtime error due to the missing function definition.

This PR correctly updates the function call to use applyLocalStorageOptions