### PR TITLE
fix: detect memo/forwardRef/HOC components missing from scan outlines…

### DIFF
--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -22,6 +22,7 @@ import {
 } from 'bippy';
 import { isValidElement } from 'preact';
 import { isEqual } from '~core/utils';
+import { getFiberName } from '~core/utils';
 import {
   collectContextChanges,
   collectPropsChanges,
@@ -543,7 +544,15 @@ export const createInstrumentation = (
         traverseRenderedFibers(
           root.current,
           (fiber: Fiber, phase: 'mount' | 'update' | 'unmount') => {
-            const type = getType(fiber.type);
+            // getType() unwraps memo/forwardRef wrappers to the underlying
+            // component function. For anonymous HOCs it may return null, so we
+            // fall back to fiber.type itself (if it's an object) to preserve
+            // the fiber and still extract a name from the wrapper.
+            const type =
+              getType(fiber.type) ??
+              (fiber.type && typeof fiber.type === 'object'
+                ? fiber.type
+                : null);
             if (!type) return null;
 
             const allInstances = getAllInstances();
@@ -610,7 +619,9 @@ export const createInstrumentation = (
             const fps = getFPS();
             const render: Render = {
               phase: RENDER_PHASE_STRING_TO_ENUM[phase],
-              componentName: getDisplayName(type),
+              // getFiberName traverses memo/forwardRef/HOC wrappers that
+              // getDisplayName(type) would return null for after getType unwraps.
+              componentName: getFiberName(fiber) ?? getDisplayName(type),
               count: 1,
               changes,
               time: fiberSelfTime,

--- a/packages/scan/src/core/utils.ts
+++ b/packages/scan/src/core/utils.ts
@@ -1,8 +1,89 @@
 // @ts-nocheck
-import { type Fiber, getType } from 'bippy';
+import {
+  type Fiber,
+  ForwardRefTag,
+  MemoComponentTag,
+  SimpleMemoComponentTag,
+  getDisplayName,
+  getType,
+} from 'bippy';
 import { ReactScanInternals } from '~core/index';
 import type { AggregatedChange, AggregatedRender, Render } from './instrumentation';
 import { IS_CLIENT } from '~web/utils/constants';
+
+/**
+ * Resolves a display name from a Fiber node, correctly handling:
+ *  - React.memo   (MemoComponentTag=10, SimpleMemoComponentTag=15):
+ *      fiber.type = { $$typeof, type: ActualComponent, compare }
+ *  - React.forwardRef (ForwardRefTag=11):
+ *      fiber.type = { $$typeof, render: ActualComponent }
+ *  - Higher-Order Components: fiber.type.displayName e.g. "connect(Foo)"
+ *
+ * Why bippy's getDisplayName(fiber) alone fails for these cases:
+ *   For memo/forwardRef, fiber.type is a wrapper *object*, not a function.
+ *   bippy checks .displayName and .name on that object — but those are not
+ *   set for anonymous wrappers, so it returns null and the fiber gets dropped
+ *   by the `if (!name) return` guard in outlineFiber().
+ */
+export function getFiberName(fiber: Fiber): string | null {
+  const { tag, type } = fiber;
+  if (!type) return null;
+
+  // Fast path: plain function / class components
+  if (typeof type === 'function') {
+    return (type as { displayName?: string; name?: string }).displayName ||
+           (type as { name?: string }).name ||
+           null;
+  }
+
+  // React.memo — tag 10 (MemoComponent) or tag 15 (SimpleMemoComponent)
+  if (tag === MemoComponentTag || tag === SimpleMemoComponentTag) {
+    const inner = (type as { type?: unknown }).type;
+    if (inner && typeof inner === 'function') {
+      return (
+        (inner as { displayName?: string }).displayName ||
+        (inner as { name?: string }).name ||
+        null
+      );
+    }
+    // devtools may set displayName on the wrapper object itself
+    return (type as { displayName?: string }).displayName || null;
+  }
+
+  // React.forwardRef — tag 11
+  if (tag === ForwardRefTag) {
+    const render = (type as { render?: unknown }).render;
+    // type.displayName is set by forwardRef(fn) when fn is named
+    const wrapperName = (type as { displayName?: string }).displayName;
+    if (wrapperName) return wrapperName;
+    if (render && typeof render === 'function') {
+      return (
+        (render as { displayName?: string }).displayName ||
+        (render as { name?: string }).name ||
+        null
+      );
+    }
+    return null;
+  }
+
+  // Generic HOC or other wrapper — bippy may resolve "connect(MyComponent)"
+  const bippyName = getDisplayName(type);
+  if (bippyName) return bippyName;
+
+  // Last resort: walk one level into .type or .render
+  const innerFallback =
+    (type as { type?: unknown }).type ||
+    (type as { render?: unknown }).render;
+  if (innerFallback && typeof innerFallback === 'function') {
+    return (
+      (innerFallback as { displayName?: string }).displayName ||
+      (innerFallback as { name?: string }).name ||
+      null
+    );
+  }
+
+  return null;
+}
 
 export const aggregateChanges = (
   changes: Array<Change>,

--- a/packages/scan/src/new-outlines/index.ts
+++ b/packages/scan/src/new-outlines/index.ts
@@ -8,6 +8,7 @@ import {
   getType,
   isCompositeFiber,
 } from 'bippy';
+import { getFiberName } from '~core/utils';
 import {
   Change,
   ContextChange,
@@ -50,8 +51,12 @@ const blueprintMapKeys = new Set<Fiber>();
 
 export const outlineFiber = (fiber: Fiber) => {
   if (!isCompositeFiber(fiber)) return;
+  // Use getFiberName to correctly resolve names for React.memo, React.forwardRef,
+  // and HOC-wrapped components. getDisplayName(fiber) returns null for wrapper
+  // objects (MemoComponent/ForwardRef fiber.type is not a plain function), causing
+  // these components to be silently dropped by the `if (!name) return` guard below.
   const name =
-    typeof fiber.type === 'string' ? fiber.type : getDisplayName(fiber);
+    typeof fiber.type === 'string' ? fiber.type : getFiberName(fiber);
   if (!name) return;
   const blueprint = blueprintMap.get(fiber);
   const nearestFibers = getNearestHostFibers(fiber);


### PR DESCRIPTION
… (Issue #252)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core instrumentation and outline generation to change how fibers are identified/named; mistakes could drop/rename components or slightly increase overhead during commit traversal.
> 
> **Overview**
> Fixes missing components in scan outlines/render logs by improving how component names are resolved for `React.memo`, `React.forwardRef`, and HOC wrappers.
> 
> Adds `getFiberName(fiber)` and uses it in both instrumentation (`componentName`) and `outlineFiber`, plus adjusts traversal to fall back from `getType()` to wrapper `fiber.type` objects so anonymous wrappers aren’t skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 707d569f65b9ae676459b44ad0b3bc8f95c3d542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->