### PR TITLE
feat(scan): ranked list search with stable bar widths

### DIFF
--- a/packages/scan/src/web/constants.ts
+++ b/packages/scan/src/web/constants.ts
@@ -10,3 +10,5 @@ export const MIN_CONTAINER_WIDTH = 240;
 export const LOCALSTORAGE_KEY = "react-scan-widget-settings-v2";
 export const LOCALSTORAGE_COLLAPSED_KEY = "react-scan-widget-collapsed-v1";
 export const LOCALSTORAGE_LAST_VIEW_KEY = "react-scan-widget-last-view-v1";
+
+export const RANKED_BAR_CHART_WIDTH_DENOMINATOR_MIN = 1e-6;

--- a/packages/scan/src/web/utils/ranked-bar-chart-search.test.ts
+++ b/packages/scan/src/web/utils/ranked-bar-chart-search.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { RANKED_BAR_CHART_WIDTH_DENOMINATOR_MIN } from '~web/constants';
+import {
+  filterSortedRankedBarsBySearch,
+  getRankedBarDisplayLabel,
+  getSafeRankedWidthDenominator,
+  rankedBarMatchesSearch,
+  type RankedBarChartBar,
+} from '~web/utils/ranked-bar-chart-search';
+
+const renderBar = (name: string, totalTime: number): RankedBarChartBar => ({
+  kind: 'render',
+  event: { name },
+  totalTime,
+});
+
+const otherJavascriptBar = (totalTime: number): RankedBarChartBar => ({
+  kind: 'other-javascript',
+  totalTime,
+});
+
+describe('getRankedBarDisplayLabel', () => {
+  it('returns component name for render bars', () => {
+    expect(getRankedBarDisplayLabel(renderBar('TodoList', 10))).toBe('TodoList');
+  });
+
+  it('returns fixed labels for non-render bars', () => {
+    expect(getRankedBarDisplayLabel(otherJavascriptBar(5))).toBe(
+      'JavaScript/React Hooks',
+    );
+    expect(
+      getRankedBarDisplayLabel({ kind: 'other-frame-drop', totalTime: 1 }),
+    ).toBe('JavaScript, DOM updates, Draw Frame');
+    expect(
+      getRankedBarDisplayLabel({ kind: 'other-not-javascript', totalTime: 2 }),
+    ).toBe('Update DOM and Draw New Frame');
+  });
+});
+
+describe('rankedBarMatchesSearch', () => {
+  it('matches every bar when query is empty', () => {
+    expect(rankedBarMatchesSearch(renderBar('Any', 1), '')).toBe(true);
+  });
+
+  it('matches case-insensitive substrings on component names', () => {
+    expect(rankedBarMatchesSearch(renderBar('TodoListForm', 1), 'todo')).toBe(
+      true,
+    );
+    expect(rankedBarMatchesSearch(renderBar('TodoListForm', 1), 'FORM')).toBe(
+      true,
+    );
+    expect(rankedBarMatchesSearch(renderBar('TodoListForm', 1), 'missing')).toBe(
+      false,
+    );
+  });
+
+  it('matches non-render bar labels', () => {
+    expect(rankedBarMatchesSearch(otherJavascriptBar(1), 'hooks')).toBe(true);
+    expect(rankedBarMatchesSearch(otherJavascriptBar(1), 'java')).toBe(true);
+  });
+});
+
+describe('filterSortedRankedBarsBySearch', () => {
+  const sortedBars: RankedBarChartBar[] = [
+    renderBar('TodoListForm', 24),
+    renderBar('TodoListItem', 6),
+    otherJavascriptBar(10),
+  ];
+
+  it('returns all bars for empty or whitespace query', () => {
+    expect(filterSortedRankedBarsBySearch(sortedBars, '')).toEqual(sortedBars);
+    expect(filterSortedRankedBarsBySearch(sortedBars, '   ')).toEqual(sortedBars);
+  });
+
+  it('returns only matching bars in original order', () => {
+    expect(filterSortedRankedBarsBySearch(sortedBars, 'TodoList')).toEqual([
+      renderBar('TodoListForm', 24),
+      renderBar('TodoListItem', 6),
+    ]);
+  });
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterSortedRankedBarsBySearch(sortedBars, 'xyz')).toEqual([]);
+  });
+});
+
+describe('getSafeRankedWidthDenominator', () => {
+  it('returns the value when above the floor', () => {
+    expect(getSafeRankedWidthDenominator(240)).toBe(240);
+  });
+
+  it('returns the minimum constant when sum is zero', () => {
+    expect(getSafeRankedWidthDenominator(0)).toBe(
+      RANKED_BAR_CHART_WIDTH_DENOMINATOR_MIN,
+    );
+  });
+});

--- a/packages/scan/src/web/utils/ranked-bar-chart-search.ts
+++ b/packages/scan/src/web/utils/ranked-bar-chart-search.ts
@@ -1,0 +1,54 @@
+import { RANKED_BAR_CHART_WIDTH_DENOMINATOR_MIN } from '~web/constants';
+
+interface RankedBarChartRenderEvent {
+  name: string;
+}
+
+export type RankedBarChartBar =
+  | { kind: 'other-frame-drop'; totalTime: number }
+  | { kind: 'other-not-javascript'; totalTime: number }
+  | { kind: 'other-javascript'; totalTime: number }
+  | { kind: 'render'; event: RankedBarChartRenderEvent; totalTime: number };
+
+export const getRankedBarDisplayLabel = (bar: RankedBarChartBar): string => {
+  switch (bar.kind) {
+    case 'other-frame-drop': {
+      return 'JavaScript, DOM updates, Draw Frame';
+    }
+    case 'other-javascript': {
+      return 'JavaScript/React Hooks';
+    }
+    case 'other-not-javascript': {
+      return 'Update DOM and Draw New Frame';
+    }
+    case 'render': {
+      return bar.event.name;
+    }
+  }
+};
+
+export const rankedBarMatchesSearch = (
+  bar: RankedBarChartBar,
+  trimmedQuery: string,
+): boolean => {
+  if (trimmedQuery === '') {
+    return true;
+  }
+  return getRankedBarDisplayLabel(bar)
+    .toLowerCase()
+    .includes(trimmedQuery.toLowerCase());
+};
+
+export const filterSortedRankedBarsBySearch = <T extends RankedBarChartBar>(
+  sortedBars: T[],
+  query: string,
+): T[] => {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery === '') {
+    return sortedBars;
+  }
+  return sortedBars.filter((bar) => rankedBarMatchesSearch(bar, trimmedQuery));
+};
+
+export const getSafeRankedWidthDenominator = (widthDenominator: number): number =>
+  Math.max(widthDenominator, RANKED_BAR_CHART_WIDTH_DENOMINATOR_MIN);

--- a/packages/scan/src/web/views/notifications/details-routes.tsx
+++ b/packages/scan/src/web/views/notifications/details-routes.tsx
@@ -138,7 +138,10 @@ export const DetailsRoutes = () => {
     case 'render-visualization': {
       return (
         <TabLayout>
-          <RenderBarChart selectedEvent={notificationState.selectedEvent} />
+          <RenderBarChart
+            key={notificationState.selectedEvent.id}
+            selectedEvent={notificationState.selectedEvent}
+          />
         </TabLayout>
       );
     }

--- a/packages/scan/src/web/views/notifications/details-routes.tsx
+++ b/packages/scan/src/web/views/notifications/details-routes.tsx
@@ -194,12 +194,14 @@ const TabLayout = ({ children }: { children: ReactNode }) => {
     );
   }
   return (
-    <div className={cn([`w-full h-full flex flex-col gap-y-2`])}>
-      <div className={cn(['h-[50px] w-full'])}>
+    <div className={cn(['flex h-full min-h-0 w-full flex-col'])}>
+      <div className={cn(['w-full shrink-0'])}>
         <NotificationTabs selectedEvent={notificationState.selectedEvent} />
       </div>
       <div
-        className={cn(['h-calc(100%-50px) flex flex-col overflow-y-auto px-3'])}
+        className={cn([
+          'flex min-h-0 flex-1 flex-col overflow-y-auto px-3 pt-2',
+        ])}
       >
         {children}
       </div>

--- a/packages/scan/src/web/views/notifications/render-bar-chart.tsx
+++ b/packages/scan/src/web/views/notifications/render-bar-chart.tsx
@@ -14,6 +14,11 @@ import {
   HighlightStore,
   drawHighlights,
 } from '~core/notifications/outline-overlay';
+import {
+  filterSortedRankedBarsBySearch,
+  getRankedBarDisplayLabel,
+  getSafeRankedWidthDenominator,
+} from '~web/utils/ranked-bar-chart-search';
 import { ChevronRight } from './icons';
 
 // todo: cleanup, convoluted ternaries
@@ -65,6 +70,7 @@ export const RenderBarChart = ({
   const totalInteractionTime = getTotalTime(selectedEvent.timing);
   const nonRender = totalInteractionTime - selectedEvent.timing.renderTime;
   const [isProduction] = useState(getIsProduction());
+  const [rankedSearchQuery, setRankedSearchQuery] = useState('');
   const events = selectedEvent.groupedFiberRenders;
   const bars: Bars = events.map((event) => ({
     event,
@@ -121,7 +127,16 @@ export const RenderBarChart = ({
     timer: null,
   });
 
-  const totalBarTime = bars.reduce((prev, curr) => prev + curr.totalTime, 0);
+  const fullTotalBarTime = bars.reduce((prev, curr) => prev + curr.totalTime, 0);
+  const safeBarWidthDenominator =
+    getSafeRankedWidthDenominator(fullTotalBarTime);
+
+  const sortedBars = bars.toSorted((a, b) => b.totalTime - a.totalTime);
+  const visibleTopLevelBars = filterSortedRankedBarsBySearch(
+    sortedBars,
+    rankedSearchQuery,
+  );
+  const rankedSearchTrimmed = rankedSearchQuery.trim();
 
   return (
     <div className={cn(['flex flex-col h-full w-full gap-y-1'])}>
@@ -152,18 +167,46 @@ export const RenderBarChart = ({
         }
       })}
 
-      {bars
-        .toSorted((a, b) => b.totalTime - a.totalTime)
-        .map((bar) => (
-          <RenderBar
-            key={bar.kind === 'render' ? bar.event.id : bar.kind}
-            bars={bars}
-            bar={bar}
-            debouncedMouseEnter={debouncedMouseEnter}
-            totalBarTime={totalBarTime}
-            isProduction={isProduction}
+      {bars.length > 0 && (
+        <div className={cn(['sticky top-0 z-[2] bg-[#0A0A0A] pb-2'])}>
+          <label className="sr-only" htmlFor="react-scan-ranked-search">
+            Search ranked components
+          </label>
+          <input
+            id="react-scan-ranked-search"
+            type="search"
+            value={rankedSearchQuery}
+            onInput={(event) =>
+              setRankedSearchQuery((event.target as HTMLInputElement).value)
+            }
+            placeholder="Search components…"
+            autoComplete="off"
+            spellcheck={false}
+            className={cn([
+              'w-full rounded-sm border border-[#27272A] bg-[#18181B] px-2.5 py-1.5',
+              'text-xs text-white placeholder:text-[#6E6E77] select-text',
+              'outline-none focus-visible:ring-2 focus-visible:ring-[#7521c8] focus-visible:border-transparent',
+            ])}
           />
-        ))}
+        </div>
+      )}
+
+      {rankedSearchTrimmed && visibleTopLevelBars.length === 0 && bars.length > 0 ? (
+        <p className={cn(['text-xs text-[#A1A1AA] py-2'])}>
+          No components match &ldquo;{rankedSearchTrimmed}&rdquo;
+        </p>
+      ) : null}
+
+      {visibleTopLevelBars.map((bar) => (
+        <RenderBar
+          key={bar.kind === 'render' ? bar.event.id : bar.kind}
+          bars={bars}
+          bar={bar}
+          debouncedMouseEnter={debouncedMouseEnter}
+          safeBarWidthDenominator={safeBarWidthDenominator}
+          isProduction={isProduction}
+        />
+      ))}
     </div>
   );
 };
@@ -184,7 +227,7 @@ const getTransitionState = (state: {
 const RenderBar = ({
   bar,
   debouncedMouseEnter,
-  totalBarTime,
+  safeBarWidthDenominator,
   isProduction,
   bars,
   depth = 0,
@@ -198,7 +241,7 @@ const RenderBar = ({
       lastCallAt: number | null;
     };
   };
-  totalBarTime: number;
+  safeBarWidthDenominator: number;
   isProduction: boolean | null;
 }) => {
   const { setNotificationState, setRoute } = useNotificationsContext();
@@ -222,6 +265,8 @@ const RenderBar = ({
             ),
         )
       : [];
+
+  const safeWidthDenominator = safeBarWidthDenominator;
 
   const handleBarClick = () => {
     if (bar.kind === 'render') {
@@ -382,7 +427,7 @@ const RenderBar = ({
           <div
             style={{
               minWidth: 'fit-content',
-              width: `${(bar.totalTime / totalBarTime) * 100}%`,
+              width: `${(bar.totalTime / safeWidthDenominator) * 100}%`,
             }}
             className={cn([
               'flex items-center rounded-sm text-white text-xs h-[28px] shrink-0',
@@ -403,22 +448,7 @@ const RenderBar = ({
           >
             <div className="flex items-center gap-x-2 min-w-0 w-full">
               <span className={cn(['truncate'])}>
-                {iife(() => {
-                  switch (bar.kind) {
-                    case 'other-frame-drop': {
-                      return 'JavaScript, DOM updates, Draw Frame';
-                    }
-                    case 'other-javascript': {
-                      return 'JavaScript/React Hooks';
-                    }
-                    case 'other-not-javascript': {
-                      return 'Update DOM and Draw New Frame';
-                    }
-                    case 'render': {
-                      return bar.event.name;
-                    }
-                  }
-                })}
+                {getRankedBarDisplayLabel(bar)}
               </span>
               {bar.kind === 'render' && isRenderMemoizable(bar.event) && (
                 <div
@@ -502,7 +532,7 @@ const RenderBar = ({
                   key={i}
                   bar={parentBar}
                   debouncedMouseEnter={debouncedMouseEnter}
-                  totalBarTime={totalBarTime}
+                  safeBarWidthDenominator={safeBarWidthDenominator}
                   isProduction={isProduction}
                   bars={bars}
                 />

--- a/packages/scan/src/web/views/notifications/render-bar-chart.tsx
+++ b/packages/scan/src/web/views/notifications/render-bar-chart.tsx
@@ -39,9 +39,9 @@ export const fadeOutHighlights = () => {
       current:
         HighlightStore.value.current?.alpha === 0
           ? // we want to only start fading from transition if current is done animating out
-            HighlightStore.value.transitionTo
+          HighlightStore.value.transitionTo
           : // if current doesn't exist then transition must exist
-            (HighlightStore.value.current ?? HighlightStore.value.transitionTo),
+          (HighlightStore.value.current ?? HighlightStore.value.transitionTo),
     };
     return;
   }
@@ -86,7 +86,7 @@ export const RenderBarChart = ({
       case 'interaction': {
         return (
           (selectedEvent.timing.otherJSTime + selectedEvent.timing.renderTime) /
-            totalInteractionTime <
+          totalInteractionTime <
           0.2
         );
       }
@@ -252,18 +252,18 @@ const RenderBar = ({
   const parentBars = bars.filter((otherBar) =>
     otherBar.kind === 'render' && bar.kind === 'render'
       ? bar.event.parents.has(otherBar.event.name) &&
-        otherBar.event.name !== bar.event.name
+      otherBar.event.name !== bar.event.name
       : false,
   );
 
   const missingParentNames =
     bar.kind === 'render'
       ? Array.from(bar.event.parents).filter(
-          (parentName) =>
-            !bars.some(
-              (b) => b.kind === 'render' && b.event.name === parentName,
-            ),
-        )
+        (parentName) =>
+          !bars.some(
+            (b) => b.kind === 'render' && b.event.name === parentName,
+          ),
+      )
       : [];
 
   const safeWidthDenominator = safeBarWidthDenominator;
@@ -362,9 +362,9 @@ const RenderBar = ({
                         kind: 'transition',
                         current: HighlightStore.value.current
                           ? {
-                              alpha: 0,
-                              ...HighlightStore.value.current,
-                            }
+                            alpha: 0,
+                            ...HighlightStore.value.current,
+                          }
                           : null,
                         transitionTo: {
                           rects: stateRects,
@@ -386,9 +386,9 @@ const RenderBar = ({
                   },
                   current: currentState
                     ? {
-                        alpha: 0,
-                        ...currentState,
-                      }
+                      alpha: 0,
+                      ...currentState,
+                    }
                     : null,
                 };
               }
@@ -433,11 +433,11 @@ const RenderBar = ({
               'flex items-center rounded-sm text-white text-xs h-[28px] shrink-0',
               bar.kind === 'render' && 'bg-[#412162] group-hover:bg-[#5b2d89]',
               bar.kind === 'other-frame-drop' &&
-                'bg-[#44444a] group-hover:bg-[#6a6a6a]',
+              'bg-[#44444a] group-hover:bg-[#6a6a6a]',
               bar.kind === 'other-javascript' &&
-                'bg-[#efd81a6b] group-hover:bg-[#efda1a2f]',
+              'bg-[#efd81a6b] group-hover:bg-[#efda1a2f]',
               bar.kind === 'other-not-javascript' &&
-                'bg-[#214379d4] group-hover:bg-[#21437982]',
+              'bg-[#214379d4] group-hover:bg-[#21437982]',
             ])}
           />
           <div

--- a/packages/scan/src/web/views/notifications/render-bar-chart.tsx
+++ b/packages/scan/src/web/views/notifications/render-bar-chart.tsx
@@ -263,10 +263,8 @@ const RenderBar = ({
           !bars.some(
             (b) => b.kind === 'render' && b.event.name === parentName,
           ),
-      )
+        )
       : [];
-
-  const safeWidthDenominator = safeBarWidthDenominator;
 
   const handleBarClick = () => {
     if (bar.kind === 'render') {
@@ -427,7 +425,7 @@ const RenderBar = ({
           <div
             style={{
               minWidth: 'fit-content',
-              width: `${(bar.totalTime / safeWidthDenominator) * 100}%`,
+              width: `${(bar.totalTime / safeBarWidthDenominator) * 100}%`,
             }}
             className={cn([
               'flex items-center rounded-sm text-white text-xs h-[28px] shrink-0',

--- a/packages/scan/src/web/widget/index.tsx
+++ b/packages/scan/src/web/widget/index.tsx
@@ -178,10 +178,21 @@ export const Widget = () => {
 
   const handleDrag = useCallback(
     (e: JSX.TargetedPointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
+      if (!refWidget.current) return;
 
-      if (!refWidget.current || (e.target as HTMLElement).closest("button"))
+      const eventTarget = e.target;
+      if (!(eventTarget instanceof HTMLElement)) return;
+
+      if (
+        eventTarget.closest("button") ||
+        eventTarget.closest(
+          'input, textarea, select, option, label, [contenteditable="true"]',
+        )
+      ) {
         return;
+      }
+
+      e.preventDefault();
 
       const container = refWidget.current;
       const containerStyle = container.style;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.2.0(next@15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 1.2.0(next@15.2.6(@playwright/test@1.58.2)(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.12
@@ -51,7 +51,7 @@ importers:
         version: 5.8.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34))
 
   kitchen-sink:
     dependencies:
@@ -140,7 +140,7 @@ importers:
         version: 4.4.4(@types/node@22.15.34)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34))
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
@@ -267,7 +267,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       react-scan:
-        specifier: '>=0.5.2'
+        specifier: '>=0.5.3'
         version: link:../scan
     devDependencies:
       '@types/babel__core':
@@ -293,7 +293,7 @@ importers:
         version: 1.5.0(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.3))(next@15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.2.0(next@15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 1.2.0(next@15.2.6(@playwright/test@1.58.2)(react@19.0.0))(react@19.0.0)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -310,7 +310,7 @@ importers:
         specifier: ^0.1.15
         version: 0.1.15(@types/react@19.1.8)(react@19.0.0)
       react-scan:
-        specifier: ^0.5.2
+        specifier: ^0.5.3
         version: link:../scan
       zod:
         specifier: ^3.23.8
@@ -4622,7 +4622,7 @@ snapshots:
       next: 15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  '@vercel/speed-insights@1.2.0(next@15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@vercel/speed-insights@1.2.0(next@15.2.6(@playwright/test@1.58.2)(react@19.0.0))(react@19.0.0)':
     optionalDependencies:
       next: 15.2.6(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
@@ -6766,7 +6766,7 @@ snapshots:
       - tsx
       - utf-8-validate
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34)(jiti@1.21.7)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.34)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2


### PR DESCRIPTION
### Fixes
This pr Fixes #432

### Main problem
Ranked slowdown lists are hard to use at scale: you can’t quickly find a component.

### Issues Resolved
- **Search** on Ranked (filter by row label, case-insensitive).
- **Usable input**: don’t steal pointer/focus from inputs (and similar controls) when dragging the widget.
- **Honest bar chart**: bar fill stays **vs the full event total**, not only visible rows after search.
- **Code quality**: small tested helpers + safe divide-by-zero guard for bar width math.

### Files
`render-bar-chart.tsx`, `details-routes.tsx`, `widget/index.tsx`, `ranked-bar-chart-search.ts`, `ranked-bar-chart-search.test.ts`, `constants.ts`

please checkout video 
[react-scan-search.webm](https://github.com/user-attachments/assets/7b07fe0a-d11e-4c17-b0f4-0ded6e51a8df)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes with small, well-tested helper utilities; main risk is minor regressions in ranked chart rendering and widget drag interactions.
> 
> **Overview**
> Adds **search filtering** to the ranked render bar list, including an empty-state message, while keeping each bar’s width scaled against the **full event total** (not just the filtered subset) and guarding against divide-by-zero via a shared minimum denominator constant.
> 
> Extracts ranked-bar label/search/width-denominator logic into a new `ranked-bar-chart-search` utility with Vitest coverage, tweaks the notification tab layout and forces `RenderBarChart` remount per selected event (`key={selectedEvent.id}`), and updates widget dragging to **not intercept pointer events** originating from form controls (inputs/selects/labels/contenteditable) or buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075718c257185ee979d8cc5bb29a8dfc1b575188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->