### PR TITLE
feat: add toolbarPosition option to configure toolbar placement (#430)

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -12,9 +12,11 @@ import type { RenderData } from 'src/core/utils';
 import { initReactScanInstrumentation } from 'src/new-outlines';
 import styles from '~web/assets/css/styles.css';
 import { createToolbar } from '~web/toolbar';
+import { applyToolbarPosition } from '~web/state';
 import { IS_CLIENT } from '~web/utils/constants';
 import { readLocalStorage, saveLocalStorage } from '~web/utils/helpers';
 import type { States } from '~web/views/inspector/utils';
+import type { ToolbarPosition, Corner } from '~web/widget/types';
 import type {
   ChangeReason,
   Render,
@@ -93,6 +95,21 @@ export interface Options {
    * @default "fast"
    */
   animationSpeed?: 'slow' | 'fast' | 'off';
+
+  /**
+   * Configure the initial position and offset of the toolbar.
+   *
+   * @example
+   * // Place toolbar at bottom-center
+   * toolbarPosition: { corner: 'bottom-center' }
+   *
+   * @example
+   * // Place toolbar at bottom-right with a 100px upward offset (avoids Next.js dev icon)
+   * toolbarPosition: { corner: 'bottom-right', y: -100 }
+   *
+   * @default { corner: 'bottom-right' }
+   */
+  toolbarPosition?: ToolbarPosition;
 
   /**
    * Track unnecessary renders, and mark their outlines gray when detected
@@ -263,6 +280,11 @@ const applyLocalStorageOptions = (options: Options): LocalStorageOptions => {
   return rest;
 };
 
+const VALID_CORNERS: Array<Corner> = [
+  'top-left', 'top-right', 'bottom-left', 'bottom-right',
+  'top-center', 'bottom-center',
+];
+
 const validateOptions = (options: Partial<Options>): Partial<Options> => {
   const errors: Array<string> = [];
   const validOptions: Partial<Options> = {};
@@ -292,6 +314,25 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
           validOptions[key] = value as 'slow' | 'fast' | 'off';
         }
         break;
+      case 'toolbarPosition': {
+        const pos = value as ToolbarPosition | undefined;
+        if (pos && typeof pos === 'object') {
+          if (pos.corner && !VALID_CORNERS.includes(pos.corner)) {
+            errors.push(
+              `- Invalid toolbar position corner "${pos.corner}". Valid values: ${VALID_CORNERS.join(', ')}`,
+            );
+          } else if (pos.x !== undefined && typeof pos.x !== 'number') {
+            errors.push(`- toolbarPosition.x must be a number. Got "${pos.x}"`);
+          } else if (pos.y !== undefined && typeof pos.y !== 'number') {
+            errors.push(`- toolbarPosition.y must be a number. Got "${pos.y}"`);
+          } else {
+            validOptions.toolbarPosition = pos;
+          }
+        } else if (pos !== undefined) {
+          errors.push(`- toolbarPosition must be an object. Got "${pos}"`);
+        }
+        break;
+      }
       case 'onCommitStart':
         if (typeof value !== 'function') {
           errors.push(`- ${key} must be a function. Got "${value}"`);
@@ -390,6 +431,16 @@ export const setOptions = (userOptions: Partial<Options>) => {
       'react-scan-options',
       applyLocalStorageOptions(newOptions),
     );
+
+    // Apply toolbar position if configured
+    if ('toolbarPosition' in validOptions && validOptions.toolbarPosition) {
+      const { corner, x, y } = validOptions.toolbarPosition;
+      applyToolbarPosition(
+        corner ?? 'bottom-right',
+        x ?? 0,
+        y ?? 0,
+      );
+    }
 
     if (shouldInitToolbar) {
       initToolbar(!!newOptions.showToolbar);

--- a/packages/scan/src/web/state.ts
+++ b/packages/scan/src/web/state.ts
@@ -10,6 +10,7 @@ import { IS_CLIENT } from "./utils/constants";
 import { readLocalStorage, saveLocalStorage } from "./utils/helpers";
 import type { Corner, WidgetConfig, WidgetSettings } from "./widget/types";
 import type { CollapsedPosition } from "./widget/types";
+import { calculatePosition } from "./widget/helpers";
 
 export const signalIsSettingsOpen = /* @__PURE__ */ signal(false);
 export const signalRefWidget = /* @__PURE__ */ signal<HTMLDivElement | null>(
@@ -39,27 +40,62 @@ export const defaultWidgetConfig = {
 
 export const getInitialWidgetConfig = (): WidgetConfig => {
   const stored = readLocalStorage<WidgetSettings>(LOCALSTORAGE_KEY);
-  if (!stored) {
-    saveLocalStorage(LOCALSTORAGE_KEY, {
-      corner: defaultWidgetConfig.corner,
-      dimensions: defaultWidgetConfig.dimensions,
-      lastDimensions: defaultWidgetConfig.lastDimensions,
-      componentsTree: defaultWidgetConfig.componentsTree,
-    });
 
-    return defaultWidgetConfig;
+  // If user has previously moved the toolbar, respect their saved position
+  if (stored) {
+    return {
+      corner: stored.corner ?? defaultWidgetConfig.corner,
+      dimensions: stored.dimensions ?? defaultWidgetConfig.dimensions,
+      lastDimensions:
+        stored.lastDimensions ??
+        stored.dimensions ??
+        defaultWidgetConfig.lastDimensions,
+      componentsTree: stored.componentsTree ?? defaultWidgetConfig.componentsTree,
+    };
   }
 
-  return {
-    corner: stored.corner ?? defaultWidgetConfig.corner,
-    dimensions: stored.dimensions ?? defaultWidgetConfig.dimensions,
+  // No saved position — check if a programmatic toolbarPosition was set
+  // We need to defer reading from ReactScanInternals here because at module
+  // load time the options may not be set yet. The actual position application
+  // happens in applyToolbarPosition() which is called after options are set.
+  saveLocalStorage(LOCALSTORAGE_KEY, {
+    corner: defaultWidgetConfig.corner,
+    dimensions: defaultWidgetConfig.dimensions,
+    lastDimensions: defaultWidgetConfig.lastDimensions,
+    componentsTree: defaultWidgetConfig.componentsTree,
+  });
 
-    lastDimensions:
-      stored.lastDimensions ??
-      stored.dimensions ??
-      defaultWidgetConfig.lastDimensions,
-    componentsTree: stored.componentsTree ?? defaultWidgetConfig.componentsTree,
+  return defaultWidgetConfig;
+};
+
+/**
+ * Called after options are set to apply toolbarPosition config.
+ * Only applies if the user hasn't manually moved the toolbar (no localStorage).
+ */
+export const applyToolbarPosition = (corner: Corner, offsetX = 0, offsetY = 0): void => {
+  const stored = readLocalStorage<WidgetSettings>(LOCALSTORAGE_KEY);
+  // Only override if the stored corner is still the default (user hasn't dragged)
+  if (stored && stored.corner !== defaultWidgetConfig.corner) {
+    return;
+  }
+
+  const position = calculatePosition(corner, MIN_SIZE.width, MIN_SIZE.height, offsetX, offsetY);
+
+  const newConfig: WidgetConfig = {
+    corner,
+    dimensions: {
+      ...defaultWidgetConfig.dimensions,
+      position,
+    },
+    lastDimensions: {
+      ...defaultWidgetConfig.lastDimensions,
+      position,
+    },
+    componentsTree: defaultWidgetConfig.componentsTree,
   };
+
+  signalWidget.value = newConfig;
+  saveLocalStorage(LOCALSTORAGE_KEY, newConfig);
 };
 
 export const signalWidget = signal<WidgetConfig>(getInitialWidgetConfig());

--- a/packages/scan/src/web/widget/helpers.ts
+++ b/packages/scan/src/web/widget/helpers.ts
@@ -93,6 +93,8 @@ export const calculatePosition = (
   corner: Corner,
   width: number,
   height: number,
+  offsetX = 0,
+  offsetY = 0,
 ): Position => {
   const isRTL = getComputedStyle(document.body).direction === 'rtl';
 
@@ -136,32 +138,40 @@ export const calculatePosition = (
       x = isRTL ? -rightBound : leftBound;
       y = topBound;
       break;
+    case 'top-center':
+      x = Math.round((windowWidth - effectiveWidth) / 2);
+      y = topBound;
+      break;
+    case 'bottom-center':
+      x = Math.round((windowWidth - effectiveWidth) / 2);
+      y = bottomBound;
+      break;
     default:
       x = leftBound;
       y = topBound;
       break;
   }
 
-  // Only ensure positions are within bounds if minimized
-  if (isMinimized) {
-    if (isRTL) {
-      // For RTL
-      x = Math.min(
-        -leftBound,
-        Math.max(x, -rightBound)
-      );
-    } else {
-      // For LTR
-      x = Math.max(
-        leftBound,
-        Math.min(x, rightBound),
-      );
-    }
-    y = Math.max(
-      topBound,
-      Math.min(y, bottomBound),
+  // Apply user-defined offsets
+  x += offsetX;
+  y += offsetY;
+
+  // Clamp to viewport bounds
+  if (isRTL) {
+    x = Math.min(
+      -leftBound,
+      Math.max(x, -rightBound)
+    );
+  } else {
+    x = Math.max(
+      leftBound,
+      Math.min(x, rightBound),
     );
   }
+  y = Math.max(
+    topBound,
+    Math.min(y, bottomBound),
+  );
 
   return { x, y };
 };
@@ -331,6 +341,8 @@ export const getClosestCorner = (position: Position): Corner => {
       windowDims.maxWidth - position.x,
       windowDims.maxHeight - position.y,
     ),
+    'top-center': Math.hypot(windowDims.maxWidth / 2 - position.x, position.y),
+    'bottom-center': Math.hypot(windowDims.maxWidth / 2 - position.x, windowDims.maxHeight - position.y),
   };
 
   let closest: Corner = 'top-left';

--- a/packages/scan/src/web/widget/types.ts
+++ b/packages/scan/src/web/widget/types.ts
@@ -8,12 +8,32 @@ export interface Size {
   height: number;
 }
 
-export type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top-center" | "bottom-center";
 
 export type CollapsedPosition = {
   corner: Corner;
   orientation: "horizontal" | "vertical";
 };
+
+export interface ToolbarPosition {
+  /**
+   * The corner/position to place the toolbar.
+   * @default "bottom-right"
+   */
+  corner?: Corner;
+  /**
+   * Horizontal offset in pixels from the computed corner position.
+   * Positive values move the toolbar to the right, negative to the left.
+   * @default 0
+   */
+  x?: number;
+  /**
+   * Vertical offset in pixels from the computed corner position.
+   * Positive values move the toolbar down, negative moves it up.
+   * @default 0
+   */
+  y?: number;
+}
 
 export interface ResizeHandleProps {
   position: Corner | "top" | "bottom" | "left" | "right";


### PR DESCRIPTION
## Summary

Adds a new `toolbarPosition` option to the `scan()` configuration, allowing users to:
- Set the initial corner/position of the toolbar (including new `top-center` and `bottom-center` options)
- Apply pixel offsets (`x`, `y`) to fine-tune placement

## Problem

The toolbar defaults to `bottom-right`, which frequently overlaps with other dev tools like the Next.js development icon (see #430).

## Solution

```ts
scan({
  toolbarPosition: {
    corner: 'bottom-center',
    x: 0,
    y: -100
  }
});
```

## Changes

- **types.ts**: Extended `Corner` type with `top-center` and `bottom-center`. Added `ToolbarPosition` interface.
- **helpers.ts**: Updated `calculatePosition()` to handle new positions and accept offset params.
- **core/index.ts**: Added `toolbarPosition` to `Options`, validation, and wiring.
- **state.ts**: Added `applyToolbarPosition()` that respects user's manual drag position.

## Backward Compatible

- Default behavior unchanged (`bottom-right`, no offset)
- User's saved position (from dragging) is always respected over programmatic config

Fixes #430

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change limited to toolbar positioning and localStorage-backed widget config; main risk is minor regressions in position calculations or clamping across RTL/viewport sizes.
> 
> **Overview**
> Adds a new `toolbarPosition` option to `scan()`/`setOptions` that lets consumers choose an initial toolbar corner and apply `x`/`y` pixel offsets.
> 
> Extends supported corners with **`top-center`** and **`bottom-center`**, updates `calculatePosition()` to apply offsets and clamp within the viewport, and wires a new `applyToolbarPosition()` in `web/state` that only overrides placement when the user hasn’t already dragged/saved a custom position.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6258d85f6743553ed7ffe5c5b9f99bbcd97af494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->