### PR TITLE
feat(scan): copy selected element via react-grab

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -1,29 +1,26 @@
-import { type Signal, signal } from '@preact/signals';
+import { type Signal, signal } from "@preact/signals";
 import {
   type Fiber,
   detectReactBuildType,
   getRDTHook,
   getType,
   isInstrumentationActive,
-} from 'bippy';
-import type { ComponentType } from 'preact';
-import type { ReactNode } from 'preact/compat';
-import type { RenderData } from 'src/core/utils';
-import { initReactScanInstrumentation } from 'src/new-outlines';
-import styles from '~web/assets/css/styles.css';
-import { createToolbar } from '~web/toolbar';
-import { IS_CLIENT } from '~web/utils/constants';
-import { readLocalStorage, saveLocalStorage } from '~web/utils/helpers';
-import { parseSafeAreaOption } from '~web/utils/parse-safe-area-option';
-import type { States } from '~web/views/inspector/utils';
-import type {
-  ChangeReason,
-  Render,
-  createInstrumentation,
-} from './instrumentation';
-import { startTimingTracking } from './notifications/event-tracking';
-import { createHighlightCanvas } from './notifications/outline-overlay';
-import packageJson from '../../package.json';
+} from "bippy";
+import type { ComponentType } from "preact";
+import type { ReactNode } from "preact/compat";
+import type { RenderData } from "src/core/utils";
+import { initReactScanInstrumentation } from "src/new-outlines";
+import styles from "~web/assets/css/styles.css";
+import { createToolbar } from "~web/toolbar";
+import { IS_CLIENT } from "~web/utils/constants";
+import { checkReactGrabVersion } from "~web/utils/check-react-grab-version";
+import { readLocalStorage, saveLocalStorage } from "~web/utils/helpers";
+import { parseSafeAreaOption } from "~web/utils/parse-safe-area-option";
+import type { States } from "~web/views/inspector/utils";
+import type { ChangeReason, Render, createInstrumentation } from "./instrumentation";
+import { startTimingTracking } from "./notifications/event-tracking";
+import { createHighlightCanvas } from "./notifications/outline-overlay";
+import packageJson from "../../package.json";
 
 let rootContainer: HTMLDivElement | null = null;
 let shadowRoot: ShadowRoot | null = null;
@@ -38,12 +35,12 @@ const initRootContainer = (): RootContainer => {
     return { rootContainer, shadowRoot };
   }
 
-  rootContainer = document.createElement('div');
-  rootContainer.id = 'react-scan-root';
+  rootContainer = document.createElement("div");
+  rootContainer.id = "react-scan-root";
 
-  shadowRoot = rootContainer.attachShadow({ mode: 'open' });
+  shadowRoot = rootContainer.attachShadow({ mode: "open" });
 
-  const cssStyles = document.createElement('style');
+  const cssStyles = document.createElement("style");
   cssStyles.textContent = styles;
 
   shadowRoot.appendChild(cssStyles);
@@ -93,7 +90,7 @@ export interface Options {
    *
    * @default "fast"
    */
-  animationSpeed?: 'slow' | 'fast' | 'off';
+  animationSpeed?: "slow" | "fast" | "off";
 
   /**
    * Track unnecessary renders, and mark their outlines gray when detected
@@ -161,7 +158,7 @@ export interface Options {
    *
    *  @default false
    */
-  _debug?: 'verbose' | false;
+  _debug?: "verbose" | false;
 
   onCommitStart?: () => void;
   onRender?: (fiber: Fiber, renders: Array<Render>) => void;
@@ -177,9 +174,7 @@ export interface StoreType {
   reportData: Map<number, RenderData>;
   legacyReportData: Map<string, RenderData>;
   changesListeners: Map<number, Array<ChangesListener>>;
-  interactionListeningForRenders:
-    | ((fiber: Fiber, renders: Array<Render>) => void)
-    | null;
+  interactionListeningForRenders: ((fiber: Fiber, renders: Array<Render>) => void) | null;
 }
 
 export type OutlineKey = `${string}-${string}`;
@@ -206,12 +201,10 @@ export type ClassComponentStateChange = {
   value: unknown;
   prevValue?: unknown;
   count?: number | undefined;
-  name: 'state';
+  name: "state";
 };
 
-export type StateChange =
-  | FunctionalComponentStateChange
-  | ClassComponentStateChange;
+export type StateChange = FunctionalComponentStateChange | ClassComponentStateChange;
 export type PropsChange = {
   type: ChangeReason.Props;
   name: string;
@@ -232,9 +225,7 @@ export type Change = StateChange | PropsChange | ContextChange;
 
 export type ChangesPayload = {
   propsChanges: Array<PropsChange>;
-  stateChanges: Array<
-    FunctionalComponentStateChange | ClassComponentStateChange
-  >;
+  stateChanges: Array<FunctionalComponentStateChange | ClassComponentStateChange>;
   contextChanges: Array<ContextChange>;
 };
 export type ChangesListener = (changes: ChangesPayload) => void;
@@ -243,7 +234,7 @@ export const Store: StoreType = {
   wasDetailsOpen: signal(true),
   isInIframe: signal(IS_CLIENT && window.self !== window.top),
   inspectState: signal<States>({
-    kind: 'uninitialized',
+    kind: "uninitialized",
   }),
   fiberRoots: new Set<Fiber>(),
   reportData: new Map<number, RenderData>(),
@@ -260,7 +251,7 @@ export const ReactScanInternals: Internals = {
     enabled: true,
     log: false,
     showToolbar: true,
-    animationSpeed: 'fast',
+    animationSpeed: "fast",
     dangerouslyForceRunInProduction: false,
     showFPS: true,
     showNotificationCount: true,
@@ -276,18 +267,10 @@ if (IS_CLIENT && window.__REACT_SCAN_EXTENSION__) {
   window.__REACT_SCAN_VERSION__ = ReactScanInternals.version;
 }
 
-export type LocalStorageOptions = Omit<
-  Options,
-  'onCommitStart' | 'onRender' | 'onCommitFinish'
->;
+export type LocalStorageOptions = Omit<Options, "onCommitStart" | "onRender" | "onCommitFinish">;
 
 const applyLocalStorageOptions = (options: Options): LocalStorageOptions => {
-  const {
-    onCommitStart,
-    onRender,
-    onCommitFinish,
-    ...rest
-  } = options;
+  const { onCommitStart, onRender, onCommitFinish, ...rest } = options;
   return rest;
 };
 
@@ -298,30 +281,28 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
   for (const key in options) {
     const value = options[key as keyof Options];
     switch (key) {
-      case 'enabled':
-      case 'log':
-      case 'showToolbar':
-      case 'showNotificationCount':
-      case 'dangerouslyForceRunInProduction':
-      case 'showFPS':
-      case 'allowInIframe':
-      case 'useOffscreenCanvasWorker':
-        if (typeof value !== 'boolean') {
+      case "enabled":
+      case "log":
+      case "showToolbar":
+      case "showNotificationCount":
+      case "dangerouslyForceRunInProduction":
+      case "showFPS":
+      case "allowInIframe":
+      case "useOffscreenCanvasWorker":
+        if (typeof value !== "boolean") {
           errors.push(`- ${key} must be a boolean. Got "${value}"`);
         } else {
           validOptions[key] = value;
         }
         break;
-      case 'animationSpeed':
-        if (!['slow', 'fast', 'off'].includes(value as string)) {
-          errors.push(
-            `- Invalid animation speed "${value}". Using default "fast"`,
-          );
+      case "animationSpeed":
+        if (!["slow", "fast", "off"].includes(value as string)) {
+          errors.push(`- Invalid animation speed "${value}". Using default "fast"`);
         } else {
-          validOptions[key] = value as 'slow' | 'fast' | 'off';
+          validOptions[key] = value as "slow" | "fast" | "off";
         }
         break;
-      case 'safeArea': {
+      case "safeArea": {
         const parsed = parseSafeAreaOption(value);
         if (parsed.ok) {
           validOptions.safeArea = parsed.value;
@@ -330,28 +311,25 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
         }
         break;
       }
-      case 'onCommitStart':
-        if (typeof value !== 'function') {
+      case "onCommitStart":
+        if (typeof value !== "function") {
           errors.push(`- ${key} must be a function. Got "${value}"`);
         } else {
           validOptions.onCommitStart = value as () => void;
         }
         break;
-      case 'onCommitFinish':
-        if (typeof value !== 'function') {
+      case "onCommitFinish":
+        if (typeof value !== "function") {
           errors.push(`- ${key} must be a function. Got "${value}"`);
         } else {
           validOptions.onCommitFinish = value as () => void;
         }
         break;
-      case 'onRender':
-        if (typeof value !== 'function') {
+      case "onRender":
+        if (typeof value !== "function") {
           errors.push(`- ${key} must be a function. Got "${value}"`);
         } else {
-          validOptions.onRender = value as (
-            fiber: Fiber,
-            renders: Array<Render>,
-          ) => void;
+          validOptions.onRender = value as (fiber: Fiber, renders: Array<Render>) => void;
         }
         break;
       default:
@@ -361,7 +339,7 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
 
   if (errors.length > 0) {
     // oxlint-disable-next-line no-console
-    console.warn(`[React Scan] Invalid options:\n${errors.join('\n')}`);
+    console.warn(`[React Scan] Invalid options:\n${errors.join("\n")}`);
   }
 
   return validOptions;
@@ -388,7 +366,7 @@ export const setOptions = (userOptions: Partial<Options>) => {
     }
 
     const shouldInitToolbar =
-      'showToolbar' in validOptions && validOptions.showToolbar !== undefined;
+      "showToolbar" in validOptions && validOptions.showToolbar !== undefined;
 
     const newOptions = {
       ...ReactScanInternals.options.value,
@@ -396,7 +374,7 @@ export const setOptions = (userOptions: Partial<Options>) => {
     };
 
     const { instrumentation } = ReactScanInternals;
-    if (instrumentation && 'enabled' in validOptions) {
+    if (instrumentation && "enabled" in validOptions) {
       instrumentation.isPaused.value = validOptions.enabled === false;
     }
 
@@ -406,18 +384,18 @@ export const setOptions = (userOptions: Partial<Options>) => {
     // we actually don't care about any other local storage option other than enabled, we should not be syncing those to local storage
     try {
       const existing = readLocalStorage<undefined | Record<string, unknown>>(
-        'react-scan-options',
+        "react-scan-options",
       )?.enabled;
 
-      if (typeof existing === 'boolean') {
+      if (typeof existing === "boolean") {
         newOptions.enabled = existing;
       }
     } catch (e) {
-      if (ReactScanInternals.options.value._debug === 'verbose') {
+      if (ReactScanInternals.options.value._debug === "verbose") {
         // oxlint-disable-next-line no-console
         console.error(
-          '[React Scan Internal Error]',
-          'Failed to create notifications outline canvas',
+          "[React Scan Internal Error]",
+          "Failed to create notifications outline canvas",
           e,
         );
       }
@@ -425,7 +403,7 @@ export const setOptions = (userOptions: Partial<Options>) => {
     }
 
     saveLocalStorage<LocalStorageOptions>(
-      'react-scan-options',
+      "react-scan-options",
       applyLocalStorageOptions(newOptions),
     );
 
@@ -435,11 +413,11 @@ export const setOptions = (userOptions: Partial<Options>) => {
 
     return newOptions;
   } catch (e) {
-    if (ReactScanInternals.options.value._debug === 'verbose') {
+    if (ReactScanInternals.options.value._debug === "verbose") {
       // oxlint-disable-next-line no-console
       console.error(
-        '[React Scan Internal Error]',
-        'Failed to create notifications outline canvas',
+        "[React Scan Internal Error]",
+        "Failed to create notifications outline canvas",
         e,
       );
     }
@@ -467,7 +445,7 @@ export const getIsProduction = () => {
   }
   for (const renderer of renderers) {
     const buildType = detectReactBuildType(renderer);
-    if (buildType !== 'production') {
+    if (buildType !== "production") {
       isProduction = false;
       return false;
     }
@@ -489,8 +467,9 @@ export const start = () => {
       return;
     }
 
-    const localStorageOptions =
-      readLocalStorage<LocalStorageOptions>('react-scan-options');
+    checkReactGrabVersion();
+
+    const localStorageOptions = readLocalStorage<LocalStorageOptions>("react-scan-options");
 
     if (localStorageOptions) {
       const validLocalOptions = validateOptions(localStorageOptions);
@@ -513,17 +492,15 @@ export const start = () => {
       setTimeout(() => {
         if (isInstrumentationActive()) return;
         // oxlint-disable-next-line no-console
-        console.error(
-          '[React Scan] Failed to load. Must import React Scan before React runs.',
-        );
+        console.error("[React Scan] Failed to load. Must import React Scan before React runs.");
       }, 5000);
     }
   } catch (e) {
-    if (ReactScanInternals.options.value._debug === 'verbose') {
+    if (ReactScanInternals.options.value._debug === "verbose") {
       // oxlint-disable-next-line no-console
       console.error(
-        '[React Scan Internal Error]',
-        'Failed to create notifications outline canvas',
+        "[React Scan Internal Error]",
+        "Failed to create notifications outline canvas",
         e,
       );
     }
@@ -558,11 +535,11 @@ const createNotificationsOutlineCanvas = () => {
     const highlightRoot = document.documentElement;
     return createHighlightCanvas(highlightRoot);
   } catch (e) {
-    if (ReactScanInternals.options.value._debug === 'verbose') {
+    if (ReactScanInternals.options.value._debug === "verbose") {
       // oxlint-disable-next-line no-console
       console.error(
-        '[React Scan Internal Error]',
-        'Failed to create notifications outline canvas',
+        "[React Scan Internal Error]",
+        "Failed to create notifications outline canvas",
         e,
       );
     }
@@ -611,7 +588,7 @@ export const ignoredProps = new WeakSet<
 >();
 
 export const ignoreScan = (node: ReactNode) => {
-  if (node && typeof node === 'object') {
+  if (node && typeof node === "object") {
     ignoredProps.add(node);
   }
 };

--- a/packages/scan/src/types.ts
+++ b/packages/scan/src/types.ts
@@ -1,26 +1,16 @@
-import type { Fiber, FiberRoot } from 'bippy';
+import type { Fiber, FiberRoot } from "bippy";
 
-type ReactScanInternals = typeof import('./core/index')['ReactScanInternals'];
-type Scan = typeof import('./index')['scan'];
+type ReactScanInternals = (typeof import("./core/index"))["ReactScanInternals"];
+type Scan = (typeof import("./index"))["scan"];
 
 export interface ExtendedReactRenderer {
   findFiberByHostInstance: (instance: Element) => Fiber | null;
   version: string;
   bundleType: number;
   rendererPackageName: string;
-  overrideHookState?: (
-    fiber: Fiber,
-    id: string,
-    path: string[],
-    value: unknown,
-  ) => void;
+  overrideHookState?: (fiber: Fiber, id: string, path: string[], value: unknown) => void;
   overrideProps?: (fiber: Fiber, path: string[], value: unknown) => void;
-  overrideContext?: (
-    fiber: Fiber,
-    contextType: unknown,
-    path: string[],
-    value: unknown,
-  ) => void;
+  overrideContext?: (fiber: Fiber, contextType: unknown, path: string[], value: unknown) => void;
 }
 
 declare global {
@@ -35,22 +25,23 @@ declare global {
 
   type TTimer = NodeJS.Timeout;
 
+  interface RequestInit {
+    priority?: "low" | "high" | "auto";
+  }
+
   interface Window {
     reactScan: Scan;
     __REACT_SCAN_TOOLBAR_CONTAINER__?: HTMLDivElement;
     __REACT_SCAN_VERSION__?: string;
     __REACT_SCAN_EXTENSION__?: boolean;
+    __REACT_GRAB__?: unknown;
     __REACT_DEVTOOLS_GLOBAL_HOOK__?: {
       checkDCE: (fn: unknown) => void;
       supportsFiber: boolean;
       supportsFlight: boolean;
       renderers: Map<number, ExtendedReactRenderer>;
       hasUnsupportedRendererAttached: boolean;
-      onCommitFiberRoot: (
-        rendererID: number,
-        root: FiberRoot,
-        priority: void | number,
-      ) => void;
+      onCommitFiberRoot: (rendererID: number, root: FiberRoot, priority: void | number) => void;
       onCommitFiberUnmount: (rendererID: number, fiber: Fiber) => void;
       onPostCommitFiberRoot: (rendererID: number, root: FiberRoot) => void;
       inject: (renderer: ExtendedReactRenderer) => number;

--- a/packages/scan/src/web/constants.ts
+++ b/packages/scan/src/web/constants.ts
@@ -1,4 +1,5 @@
 export const SAFE_AREA = 24;
+export const COPY_FEEDBACK_DURATION_MS = 600;
 export const MIN_SIZE = {
   width: 550,
   height: 350,

--- a/packages/scan/src/web/utils/check-react-grab-version.ts
+++ b/packages/scan/src/web/utils/check-react-grab-version.ts
@@ -1,0 +1,37 @@
+import { version as REACT_GRAB_VERSION } from "react-grab/package.json";
+
+let didRunVersionCheck = false;
+
+export const checkReactGrabVersion = (): void => {
+  if (didRunVersionCheck) return;
+  didRunVersionCheck = true;
+
+  if (typeof window === "undefined") return;
+  if (window.__REACT_GRAB__) return;
+  if (!navigator.onLine) return;
+  if (!REACT_GRAB_VERSION) return;
+
+  const fetchOptions: RequestInit = {
+    referrerPolicy: "origin",
+    keepalive: true,
+    priority: "low",
+    cache: "no-store",
+  };
+
+  try {
+    fetch(
+      `https://www.react-grab.com/api/version?source=react-scan&v=${REACT_GRAB_VERSION}&t=${Date.now()}`,
+      fetchOptions,
+    )
+      .then((response) => response.text())
+      .then((latestVersion) => {
+        if (latestVersion && latestVersion !== REACT_GRAB_VERSION) {
+          // oxlint-disable-next-line no-console
+          console.warn(
+            `[React Scan] react-grab v${REACT_GRAB_VERSION} is outdated (latest: v${latestVersion}). Update react-scan to pick up the newer react-grab.`,
+          );
+        }
+      })
+      .catch(() => null);
+  } catch {}
+};

--- a/packages/scan/src/web/utils/check-react-grab-version.ts
+++ b/packages/scan/src/web/utils/check-react-grab-version.ts
@@ -24,8 +24,9 @@ export const checkReactGrabVersion = (): void => {
       fetchOptions,
     )
       .then((response) => (response.ok ? response.text() : null))
-      .then((latestVersion) => {
-        if (!latestVersion) return;
+      .then((rawLatestVersion) => {
+        if (!rawLatestVersion) return;
+        const latestVersion = rawLatestVersion.trim();
         if (!/^\d+\.\d+\.\d+/.test(latestVersion)) return;
         if (latestVersion === REACT_GRAB_VERSION) return;
         // oxlint-disable-next-line no-console

--- a/packages/scan/src/web/utils/check-react-grab-version.ts
+++ b/packages/scan/src/web/utils/check-react-grab-version.ts
@@ -23,14 +23,15 @@ export const checkReactGrabVersion = (): void => {
       `https://www.react-grab.com/api/version?source=react-scan&v=${REACT_GRAB_VERSION}&t=${Date.now()}`,
       fetchOptions,
     )
-      .then((response) => response.text())
+      .then((response) => (response.ok ? response.text() : null))
       .then((latestVersion) => {
-        if (latestVersion && latestVersion !== REACT_GRAB_VERSION) {
-          // oxlint-disable-next-line no-console
-          console.warn(
-            `[React Scan] react-grab v${REACT_GRAB_VERSION} is outdated (latest: v${latestVersion}). Update react-scan to pick up the newer react-grab.`,
-          );
-        }
+        if (!latestVersion) return;
+        if (!/^\d+\.\d+\.\d+/.test(latestVersion)) return;
+        if (latestVersion === REACT_GRAB_VERSION) return;
+        // oxlint-disable-next-line no-console
+        console.warn(
+          `[React Scan] react-grab v${REACT_GRAB_VERSION} is outdated (latest: v${latestVersion}). Update react-scan to pick up the newer react-grab.`,
+        );
       })
       .catch(() => null);
   } catch {}

--- a/packages/scan/src/web/utils/copy-focused-element.ts
+++ b/packages/scan/src/web/utils/copy-focused-element.ts
@@ -1,11 +1,10 @@
 import { getElementContext } from "react-grab/primitives";
 
 export const copyFocusedElement = async (element: Element): Promise<boolean> => {
-  const context = await getElementContext(element);
-  const snippet = `${context.htmlPreview}${context.stackString}`;
-  if (!snippet.trim()) return false;
-
   try {
+    const context = await getElementContext(element);
+    const snippet = `${context.htmlPreview}${context.stackString}`;
+    if (!snippet.trim()) return false;
     await navigator.clipboard.writeText(snippet);
     return true;
   } catch {

--- a/packages/scan/src/web/utils/copy-focused-element.ts
+++ b/packages/scan/src/web/utils/copy-focused-element.ts
@@ -1,0 +1,14 @@
+import { getElementContext } from "react-grab/primitives";
+
+export const copyFocusedElement = async (element: Element): Promise<boolean> => {
+  const context = await getElementContext(element);
+  const snippet = `${context.htmlPreview}${context.stackString}`;
+  if (!snippet.trim()) return false;
+
+  try {
+    await navigator.clipboard.writeText(snippet);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/scan/src/web/utils/has-non-empty-text-selection.ts
+++ b/packages/scan/src/web/utils/has-non-empty-text-selection.ts
@@ -1,0 +1,4 @@
+export const hasNonEmptyTextSelection = (): boolean => {
+  const selection = window.getSelection?.();
+  return Boolean(selection && selection.toString().length > 0);
+};

--- a/packages/scan/src/web/utils/is-input-like-focused.ts
+++ b/packages/scan/src/web/utils/is-input-like-focused.ts
@@ -1,0 +1,8 @@
+export const isInputLikeFocused = (): boolean => {
+  const active = document.activeElement;
+  if (!active) return false;
+  const tag = active.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (active instanceof HTMLElement && active.isContentEditable) return true;
+  return false;
+};

--- a/packages/scan/src/web/utils/is-mac.ts
+++ b/packages/scan/src/web/utils/is-mac.ts
@@ -1,0 +1,6 @@
+export const isMac = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || "";
+  if (platform) return /Mac|iPhone|iPad|iPod/i.test(platform);
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+};

--- a/packages/scan/src/web/utils/is-user-react-grab-active.ts
+++ b/packages/scan/src/web/utils/is-user-react-grab-active.ts
@@ -1,0 +1,2 @@
+export const isUserReactGrabActive = (): boolean =>
+  typeof window !== "undefined" && Boolean(window.__REACT_GRAB__);

--- a/packages/scan/src/web/widget/header.tsx
+++ b/packages/scan/src/web/widget/header.tsx
@@ -47,6 +47,7 @@ export const Header = () => {
       if (state.kind !== "focused" || !state.focusedDomElement) return;
       if (isUserReactGrabActive()) return;
       if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.shiftKey || event.altKey) return;
       if (event.key !== "c" && event.code !== "KeyC") return;
       if (isInputLikeFocused() || hasNonEmptyTextSelection()) return;
 

--- a/packages/scan/src/web/widget/header.tsx
+++ b/packages/scan/src/web/widget/header.tsx
@@ -1,51 +1,98 @@
-import { Store } from '~core/index';
-import { Icon } from '~web/components/icon';
-import { useDelayedValue } from '~web/hooks/use-delayed-value';
-import { signalWidgetViews } from '~web/state';
-import { cn } from '~web/utils/helpers';
-import { HeaderInspect } from '~web/views/inspector/header';
+import { useSignal } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import { Store } from "~core/index";
+import { Icon } from "~web/components/icon";
+import { COPY_FEEDBACK_DURATION_MS } from "~web/constants";
+import { useDelayedValue } from "~web/hooks/use-delayed-value";
+import { signalWidgetViews } from "~web/state";
+import { copyFocusedElement } from "~web/utils/copy-focused-element";
+import { hasNonEmptyTextSelection } from "~web/utils/has-non-empty-text-selection";
+import { cn } from "~web/utils/helpers";
+import { isInputLikeFocused } from "~web/utils/is-input-like-focused";
+import { isMac } from "~web/utils/is-mac";
+import { isUserReactGrabActive } from "~web/utils/is-user-react-grab-active";
+import { HeaderInspect } from "~web/views/inspector/header";
 
 export const Header = () => {
-  const isInitialView = useDelayedValue(
-    Store.inspectState.value.kind === 'focused',
-    150,
-    0,
-  );
+  const isInitialView = useDelayedValue(Store.inspectState.value.kind === "focused", 150, 0);
+  const isCopied = useSignal(false);
+
   const handleClose = () => {
     signalWidgetViews.value = {
-      view: 'none',
+      view: "none",
     };
     Store.inspectState.value = {
-      kind: 'inspect-off',
+      kind: "inspect-off",
     };
   };
 
-  const isHeaderIsNotifications =
-    signalWidgetViews.value.view === 'notifications';
+  const handleCopy = async () => {
+    const state = Store.inspectState.value;
+    if (state.kind !== "focused" || !state.focusedDomElement) return;
+    const didCopy = await copyFocusedElement(state.focusedDomElement);
+    if (!didCopy) return;
+    isCopied.value = true;
+    setTimeout(() => {
+      isCopied.value = false;
+      handleClose();
+    }, COPY_FEEDBACK_DURATION_MS);
+  };
+
+  const refHandleCopy = useRef(handleCopy);
+  refHandleCopy.current = handleCopy;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const state = Store.inspectState.value;
+      if (state.kind !== "focused" || !state.focusedDomElement) return;
+      if (isUserReactGrabActive()) return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.key !== "c" && event.code !== "KeyC") return;
+      if (isInputLikeFocused() || hasNonEmptyTextSelection()) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void refHandleCopy.current();
+    };
+
+    document.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, { capture: true });
+    };
+  }, []);
+
+  const isHeaderIsNotifications = signalWidgetViews.value.view === "notifications";
 
   if (isHeaderIsNotifications) {
     return;
   }
 
+  const isFocused = Store.inspectState.value.kind === "focused";
+  const copyShortcutLabel = isMac() ? "⌘C" : "Ctrl+C";
+
   return (
     <div className="react-scan-header">
       <div className="relative flex-1 h-full">
-        <div
-          className={cn(
-            'react-scan-header-item is-visible',
-            !isInitialView && '!duration-0',
-          )}
-        >
+        <div className={cn("react-scan-header-item is-visible", !isInitialView && "!duration-0")}>
           <HeaderInspect />
         </div>
       </div>
 
-      <button
-        type="button"
-        title="Close"
-        className="react-scan-close-button"
-        onClick={handleClose}
-      >
+      {isFocused && (
+        <button
+          type="button"
+          title={`Copy element (${copyShortcutLabel})`}
+          className="react-scan-close-button"
+          onClick={handleCopy}
+        >
+          <Icon
+            name={isCopied.value ? "icon-check" : "icon-copy"}
+            className={cn(isCopied.value && "text-green-500")}
+          />
+        </button>
+      )}
+
+      <button type="button" title="Close" className="react-scan-close-button" onClick={handleClose}>
         <Icon name="icon-close" />
       </button>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,7 +242,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       react-scan:
-        specifier: '>=0.5.4'
+        specifier: '>=0.5.5'
         version: link:../scan
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@^0.1.12


### PR DESCRIPTION
## Summary

Adds a way to copy the currently-selected element from the inspector as an HTML preview + React owner stack snippet, ready to paste into a coding agent. The integration is light — it leans on `react-grab/primitives.getElementContext` for the snippet generation and falls through to the native `navigator.clipboard.writeText`. No react-grab UI is loaded.

- Copy button next to the X close button in the inspector header (only when an element is focused)
- Cmd+C / Ctrl+C while focused does the same thing (capture-phase listener with input/text-selection guards)
- Both paths dismiss the inspector after a brief check-icon flash
- One-shot fetch to `react-grab.com/api/version?source=react-scan` after the production/`enabled` gate, mirroring react-grab's `log-intro.ts`. Logs a `console.warn` if react-grab in `node_modules` is outdated.
- Co-exists with a user-installed react-grab: when `window.__REACT_GRAB__` is present we defer to it for both the keyboard shortcut and the version-check fetch, so there's no double-copy and no duplicate ping.

## What's new

| File | Purpose |
| --- | --- |
| `packages/scan/src/web/utils/copy-focused-element.ts` | Composes `${htmlPreview}${stackString}` from `react-grab/primitives.getElementContext` and writes via `navigator.clipboard.writeText` |
| `packages/scan/src/web/utils/check-react-grab-version.ts` | One-shot version check, gated on `!window.__REACT_GRAB__` and `navigator.onLine` |
| `packages/scan/src/web/utils/is-input-like-focused.ts` | Cmd+C guard helper |
| `packages/scan/src/web/utils/has-non-empty-text-selection.ts` | Cmd+C guard helper (preserves native copy when user has selected text) |
| `packages/scan/src/web/utils/is-user-react-grab-active.ts` | Detects `window.__REACT_GRAB__` |
| `packages/scan/src/web/utils/is-mac.ts` | Used to render `⌘C` vs `Ctrl+C` in the button title |

## What changed

- `packages/scan/src/web/widget/header.tsx`: render the copy button when focused, register the Cmd+C listener, swap `icon-copy` → `icon-check` for `COPY_FEEDBACK_DURATION_MS` then dismiss
- `packages/scan/src/web/constants.ts`: new `COPY_FEEDBACK_DURATION_MS = 600`
- `packages/scan/src/core/index.ts`: call `checkReactGrabVersion()` from `start()` after the production gate
- `packages/scan/src/types.ts`: declare `window.__REACT_GRAB__?: unknown` and augment `RequestInit` with `priority`

## Bundle impact

`auto.global.js` 342 KB → 374 KB (+32 KB minified). All from the `react-grab/primitives` chunks (`freeze-updates-*`, `dist-*`, `extract-element-css-*`). We deliberately use `/primitives` instead of `/core` to skip the ~101 KB solid-js + toolbar UI chunk.

## Test plan

- [ ] `pnpm build` — succeeds, bundle delta as above
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — same warning/error counts as `main` (no new lint issues)
- [ ] Manual (no react-grab installed): open the inspector, focus an element, click copy → snippet on clipboard, inspector dismisses
- [ ] Manual (no react-grab installed): focus an element, press Cmd+C → same result
- [ ] Manual (input focused or text selected): Cmd+C does NOT trigger our handler — native browser copy still works
- [ ] Manual (`<script src="//unpkg.com/react-grab"></script>` loaded before react-scan): only react-grab's toolbar appears, our copy button still works (uses our bundled primitives), Cmd+C lets react-grab handle it (no double-copy), only one `react-grab.com/api/version` fetch in the network panel
- [ ] Manual: confirm Mac renders `⌘C` in the title and Windows/Linux render `Ctrl+C`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds global capture-phase Cmd/Ctrl+C handling, clipboard writes, and a one-shot external version-check fetch, which can affect user interactions and network/privacy expectations if misfired.
> 
> **Overview**
> Adds a **copy focused element** affordance in the inspector header: when an element is focused, a new copy button (and Cmd/Ctrl+C shortcut) copies an `${htmlPreview}${stackString}` snippet generated via `react-grab/primitives.getElementContext`, briefly shows success feedback, then dismisses the inspector.
> 
> Introduces guards to avoid hijacking native copy (input/contenteditable focus, non-empty text selection) and defers shortcut handling when a user-installed `react-grab` is detected via `window.__REACT_GRAB__`. Also adds a one-shot startup call (`start()`) to `checkReactGrabVersion()` which pings `react-grab.com` to warn if the bundled `react-grab` version is outdated, plus related type/global and constants updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd055d44d2ccd61ace7dc8e8b5eeb39bffaf9aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->