### PR TITLE
Feat/tanstack devtools plugin

### DIFF
--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -94,6 +94,11 @@
       "import": "./dist/lite/index.mjs",
       "require": "./dist/lite/index.js"
     },
+    "./tanstack-plugin": {
+      "types": "./dist/tanstack-plugin/index.d.ts",
+      "import": "./dist/tanstack-plugin/index.mjs",
+      "require": "./dist/tanstack-plugin/index.js"
+    },
     "./auto": {
       "production": {
         "import": {
@@ -193,6 +198,9 @@
       ],
       "react-component-name/loader": [
         "./dist/react-component-name/loader.d.ts"
+      ],
+      "tanstack-plugin": [
+        "./dist/tanstack-plugin/index.d.ts"
       ]
     }
   },

--- a/packages/scan/src/tanstack-plugin/index.tsx
+++ b/packages/scan/src/tanstack-plugin/index.tsx
@@ -1,0 +1,105 @@
+import { render } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { scan } from '~core/index';
+import type { Options } from '~core/index';
+import styles from '~web/assets/css/styles.css';
+import { SvgSprite } from '~web/components/svg-sprite';
+import { ToolbarElementContext } from '~web/toolbar-context';
+import { Content } from '~web/views';
+import { ScanOverlay } from '~web/views/inspector/overlay';
+
+// Structural type matching TanStackDevtoolsPlugin — no runtime @tanstack/devtools dependency.
+export interface ReactScanTanStackPlugin {
+  id?: string;
+  name: string;
+  defaultOpen?: boolean;
+  render: (el: HTMLDivElement, props: Record<string, unknown>) => void;
+  destroy?: (pluginId: string) => void;
+}
+
+const TanStackPanel = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Force a re-render after mount so ToolbarElementContext receives the live DOM ref,
+  // enabling portal targets in popovers and other-visualization.
+  const [, forceUpdate] = useState(false);
+  useEffect(() => {
+    forceUpdate(true);
+  }, []);
+
+  return (
+    <ToolbarElementContext.Provider value={containerRef.current}>
+      <ScanOverlay />
+      <div
+        ref={containerRef}
+        style={{
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <Content />
+      </div>
+    </ToolbarElementContext.Provider>
+  );
+};
+
+/**
+ * Creates a TanStack DevTools plugin that embeds React Scan's inspector,
+ * notifications, and scan controls inside the TanStack DevTools panel.
+ *
+ * @example
+ * ```tsx
+ * import { TanStackDevtools } from '@tanstack/react-devtools';
+ * import { createReactScanPlugin } from 'react-scan/tanstack-plugin';
+ *
+ * <TanStackDevtools plugins={[createReactScanPlugin()]} />
+ * ```
+ *
+ * React Scan's render outline overlays continue to appear on the page as usual.
+ * The floating toolbar is suppressed — all controls live inside the TanStack panel.
+ */
+export function createReactScanPlugin(
+  options: Omit<Options, 'showToolbar'> = {},
+): ReactScanTanStackPlugin {
+  let shadowRoot: ShadowRoot | null = null;
+  let container: HTMLDivElement | null = null;
+
+  return {
+    id: 'react-scan',
+    name: 'React Scan',
+    render(el) {
+      // Start scanning without the floating widget.
+      scan({ ...options, showToolbar: false });
+
+      // Create an isolated shadow root — same pattern as initRootContainer in core/index.ts.
+      shadowRoot = el.attachShadow({ mode: 'open' });
+
+      const styleEl = document.createElement('style');
+      styleEl.textContent = styles;
+      shadowRoot.appendChild(styleEl);
+
+      container = document.createElement('div');
+      container.style.cssText = 'height:100%;display:flex;flex-direction:column;';
+      shadowRoot.appendChild(container);
+
+      render(
+        <>
+          <SvgSprite />
+          <TanStackPanel />
+        </>,
+        container,
+      );
+    },
+    destroy() {
+      if (container) {
+        // Double render(null) is required to fully unmount Preact components
+        // and flush internal VNode references and event listeners.
+        render(null, container);
+        render(null, container);
+        container = null;
+        shadowRoot = null;
+      }
+    },
+  };
+}

--- a/packages/scan/src/web/toolbar-context.ts
+++ b/packages/scan/src/web/toolbar-context.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'preact';
+
+export const ToolbarElementContext = createContext<HTMLElement | null>(null);

--- a/packages/scan/src/web/widget/index.tsx
+++ b/packages/scan/src/web/widget/index.tsx
@@ -1,4 +1,5 @@
-import { createContext, type JSX } from "preact";
+import type { JSX } from "preact";
+import { ToolbarElementContext } from '~web/toolbar-context';
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { Store, ReactScanInternals } from "~core/index";
 import {
@@ -757,4 +758,4 @@ export const Widget = () => {
   );
 };
 
-export const ToolbarElementContext = createContext<HTMLElement | null>(null);
+export { ToolbarElementContext } from '~web/toolbar-context';

--- a/packages/scan/tsup.config.ts
+++ b/packages/scan/tsup.config.ts
@@ -124,6 +124,7 @@ export default defineConfig([
       './src/install-hook.ts',
       './src/core/all-environments.ts',
       './src/lite/index.ts',
+      './src/tanstack-plugin/index.tsx',
     ],
     banner: {
       js: banner,
@@ -144,6 +145,7 @@ export default defineConfig([
       await addDirectivesToChunkFiles(DIST_PATH);
       await addDirectivesToChunkFiles(path.join(DIST_PATH, 'lite'));
       await addDirectivesToChunkFiles(path.join(DIST_PATH, 'core'));
+      await addDirectivesToChunkFiles(path.join(DIST_PATH, 'tanstack-plugin'));
     },
     minify: false,
     env: {


### PR DESCRIPTION
PR Description Provided By Copilot. 

This pull request adds a new TanStack DevTools plugin integration for React Scan, enabling the inspector and controls to be embedded directly inside the TanStack DevTools panel. The changes introduce a new entry point, update the package build and exports, and refactor the toolbar context for reuse.

**TanStack DevTools plugin integration:**

* Added a new `createReactScanPlugin` function in `tanstack-plugin/index.tsx` to provide a TanStack DevTools-compatible plugin that renders the React Scan inspector, controls, and overlays within the DevTools panel. This includes a custom `TanStackPanel` component and ensures isolation via a shadow root.
* Registered the new plugin entry point in the package build (`tsup.config.ts`) and exports (`package.json`), ensuring it is bundled and available for consumers. [[1]](diffhunk://#diff-64957c9397694582d61aae1adcfd7e2326c4d2c1988c7d7fd59aeb698ee22c6aR127) [[2]](diffhunk://#diff-64957c9397694582d61aae1adcfd7e2326c4d2c1988c7d7fd59aeb698ee22c6aR148) [[3]](diffhunk://#diff-fb72e6b2792f402de2ce760446d9dfcf90496d15a39910dd4ed84c4b4d9c98cfR97-R101) [[4]](diffhunk://#diff-fb72e6b2792f402de2ce760446d9dfcf90496d15a39910dd4ed84c4b4d9c98cfR201-R203)

**Codebase refactoring for context sharing:**

* Moved `ToolbarElementContext` to a dedicated module (`web/toolbar-context.ts`) for reuse between the widget and the new plugin, and updated imports accordingly. [[1]](diffhunk://#diff-0dc29f1416d27282eac0d9f11f8c02f74ab5ab689cc21f4005b82349a33cade6R1-R3) [[2]](diffhunk://#diff-37da5ba91b1f69d49e969c0db336ad52fafbadc295cfd0035646fd1098fedce9L1-R2) [[3]](diffhunk://#diff-37da5ba91b1f69d49e969c0db336ad52fafbadc295cfd0035646fd1098fedce9L760-R761)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new integration entrypoint that mounts React Scan UI into TanStack DevTools via a shadow root and changes build/exports, which could affect bundling/runtime mounting behavior but doesn’t touch auth or data persistence logic.
> 
> **Overview**
> Adds a new `react-scan/tanstack-plugin` export with `createReactScanPlugin()` to run `scan({showToolbar:false})` and mount the React Scan UI (overlay + main `Content`) inside a TanStack DevTools panel using a shadow-root container.
> 
> Refactors `ToolbarElementContext` into a shared `~web/toolbar-context` module (with `~web/widget` re-exporting it) so both the floating widget and TanStack panel can provide a consistent portal/root element.
> 
> Updates packaging to ship this new entrypoint: registers it in `tsup` build entries (including `use client` directive injection for the new output dir) and exposes types/JS via `package.json` `exports` + `typesVersions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c398cf1ff57ab91a0924167dd163a52dd2ef73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->