### PR TITLE
Correct spacing in React Scan description

### DIFF
--- a/packages/website/app/page.tsx
+++ b/packages/website/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-4 text-base sm:text-lg">
       <div className="text-pretty text-white">
-        <span className="font-bold">React&nbsp;Scan</span> automatically detects performance issues
+        <span className="font-bold">React&nbsp;Scan</span>&nbsp;automatically detects performance issues
         in your React&nbsp;app.
       </div>
 


### PR DESCRIPTION
## Summary

Corrects the missing space between “React Scan” and the following text in the website description.

## Checks

Not run — small text-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only change to the marketing copy on the website homepage; no functional, security, or data-handling impact.
> 
> **Overview**
> Fixes a missing space in the homepage description by inserting an explicit `&nbsp;` after `React&nbsp;Scan`, ensuring the hero text renders with proper spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25abdc7195e7b5ff798d587a6547e1aedfa1d2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->