### PR TITLE
test(e2e): deep Playwright coverage for the React Scan overlay UI

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,23 @@
-import { type Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 export const FIXTURE_URL = '/?example=e2e-fixture';
+
+export const TOOLBAR_SELECTORS = {
+  root: '#react-scan-root',
+  widget: '#react-scan-toolbar',
+  inspectButton: '#react-scan-inspect-element',
+  notificationsButton: '#react-scan-notifications',
+  outlineToggle: '.react-scan-toggle input[type="checkbox"]',
+  closeButton: '.react-scan-close-button[title="Close"]',
+  inspectorPanel: '.react-scan-inspector',
+  overlayCanvas: 'canvas.react-scan-inspector-overlay',
+} as const;
+
+export type InspectStateKind =
+  | 'uninitialized'
+  | 'inspect-off'
+  | 'inspecting'
+  | 'focused';
 
 export async function gotoFixture(page: Page): Promise<void> {
   await page.goto(FIXTURE_URL);
@@ -77,4 +94,110 @@ export async function hasShadowRoot(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     return document.getElementById('react-scan-root')?.shadowRoot != null;
   });
+}
+
+export async function getInspectStateKind(
+  page: Page,
+): Promise<InspectStateKind | null> {
+  return page.evaluate(() => {
+    const scan = (window as any).__REACT_SCAN__;
+    return scan?.ReactScanInternals?.Store?.inspectState?.value?.kind ?? null;
+  });
+}
+
+export async function waitForInspectStateKind(
+  page: Page,
+  expectedKind: InspectStateKind,
+  timeout = 5000,
+): Promise<void> {
+  await page.waitForFunction(
+    (kind) => {
+      const scan = (window as any).__REACT_SCAN__;
+      return (
+        scan?.ReactScanInternals?.Store?.inspectState?.value?.kind === kind
+      );
+    },
+    expectedKind,
+    { timeout },
+  );
+}
+
+export async function isOutlineInstrumentationPaused(
+  page: Page,
+): Promise<boolean | null> {
+  return page.evaluate(() => {
+    const scan = (window as any).__REACT_SCAN__;
+    const instrumentation = scan?.ReactScanInternals?.instrumentation;
+    return instrumentation?.isPaused?.value ?? null;
+  });
+}
+
+// The overlay UI is mounted inside an open shadow root; Playwright CSS
+// locators pierce open shadow roots automatically, so plain selectors work.
+export function toolbarWidget(page: Page): Locator {
+  return page.locator(TOOLBAR_SELECTORS.widget);
+}
+
+export function inspectButton(page: Page): Locator {
+  return page.locator(TOOLBAR_SELECTORS.inspectButton);
+}
+
+export function notificationsButton(page: Page): Locator {
+  return page.locator(TOOLBAR_SELECTORS.notificationsButton);
+}
+
+export function outlineToggle(page: Page): Locator {
+  return page.locator(TOOLBAR_SELECTORS.outlineToggle);
+}
+
+export async function waitForToolbarReady(page: Page): Promise<void> {
+  await inspectButton(page).waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+// When the widget is expanded, the absolutely-positioned resize handles sit on
+// top of the toolbar controls and swallow coordinate-based pointer events.
+// Dispatching the click directly on the control drives its handler regardless
+// of layering, which is what we want when asserting control behavior.
+export async function clickToolbarControl(locator: Locator): Promise<void> {
+  await locator.dispatchEvent('click');
+}
+
+// The overlay buttons live in the shadow root, so clicking them makes the
+// shadow host the document's active element. Blurring restores focus to the
+// page, matching the scenario the global Escape shortcut is meant for.
+export async function blurOverlay(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const active = document.activeElement as HTMLElement | null;
+    active?.blur();
+  });
+}
+
+export async function enterInspectMode(page: Page): Promise<void> {
+  await waitForToolbarReady(page);
+  await inspectButton(page).click();
+  await waitForInspectStateKind(page, 'inspecting');
+}
+
+export async function focusComponent(
+  page: Page,
+  targetSelector: string,
+): Promise<void> {
+  // While inspecting, the overlay event-catcher covers the page, so the
+  // standard element-targeted click fails Playwright actionability checks.
+  // Drive raw pointer coordinates instead: the overlay resolves the element
+  // under the cursor on pointermove (throttled at 32ms) and locks focus on
+  // click. Two nudged moves defeat the throttle's leading-edge gate.
+  const box = await page.locator(targetSelector).boundingBox();
+  if (!box) {
+    throw new Error(`Target ${targetSelector} has no bounding box`);
+  }
+  const centerX = box.x + box.width / 2;
+  const centerY = box.y + box.height / 2;
+
+  await page.mouse.move(centerX, centerY);
+  await page.waitForTimeout(40);
+  await page.mouse.move(centerX + 1, centerY + 1);
+  await page.waitForTimeout(40);
+  await page.mouse.click(centerX, centerY);
+  await waitForInspectStateKind(page, 'focused');
 }

--- a/e2e/overlay-inspector.spec.ts
+++ b/e2e/overlay-inspector.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+import {
+  gotoFixture,
+  enterInspectMode,
+  focusComponent,
+  inspectButton,
+  clickToolbarControl,
+  blurOverlay,
+  getInspectStateKind,
+  waitForInspectStateKind,
+  waitForToolbarReady,
+  TOOLBAR_SELECTORS,
+} from './helpers';
+
+const COMPONENT_TREE_SEARCH = 'input[placeholder="Component name, /regex/, or [type]"]';
+
+test.describe('Overlay inspector flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+    await waitForToolbarReady(page);
+  });
+
+  test('inspecting mode activates the overlay canvas', async ({ page }) => {
+    await enterInspectMode(page);
+    const overlay = page.locator(TOOLBAR_SELECTORS.overlayCanvas);
+    await expect(overlay).toHaveCount(1);
+  });
+
+  test('clicking a component while inspecting focuses it', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+    expect(await getInspectStateKind(page)).toBe('focused');
+  });
+
+  test('focusing a component opens the inspector panel', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    await expect(page.locator(TOOLBAR_SELECTORS.inspectorPanel)).toBeVisible();
+    await expect(page.locator(COMPONENT_TREE_SEARCH)).toBeVisible();
+  });
+
+  test('inspector header shows the focused component name', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    await expect(
+      page.locator(`${TOOLBAR_SELECTORS.widget} >> text=Counter`).first(),
+    ).toBeVisible();
+  });
+
+  test('a copy button appears when a component is focused', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    await expect(
+      page.locator('.react-scan-close-button[title*="Copy element"]'),
+    ).toBeVisible();
+  });
+
+  test('close button exits inspection back to inspect-off', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    await clickToolbarControl(page.locator(TOOLBAR_SELECTORS.closeButton));
+    await waitForInspectStateKind(page, 'inspect-off');
+    expect(await getInspectStateKind(page)).toBe('inspect-off');
+  });
+
+  test('pressing Escape returns from focused to inspecting', async ({ page }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    await blurOverlay(page);
+    await page.keyboard.press('Escape');
+    await waitForInspectStateKind(page, 'inspecting');
+    expect(await getInspectStateKind(page)).toBe('inspecting');
+  });
+
+  test('re-focusing a different component keeps the inspector open', async ({
+    page,
+  }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+    expect(await getInspectStateKind(page)).toBe('focused');
+
+    await blurOverlay(page);
+    await page.keyboard.press('Escape');
+    await waitForInspectStateKind(page, 'inspecting');
+
+    await focusComponent(page, '[data-testid="toggle-theme"]');
+    expect(await getInspectStateKind(page)).toBe('focused');
+    await expect(page.locator(TOOLBAR_SELECTORS.inspectorPanel)).toBeVisible();
+  });
+
+  test('toggling inspect button off while focused tears down the panel', async ({
+    page,
+  }) => {
+    await enterInspectMode(page);
+    await focusComponent(page, '[data-testid="increment"]');
+
+    // From "focused" the inspect button advances to "inspecting".
+    await clickToolbarControl(inspectButton(page));
+    await waitForInspectStateKind(page, 'inspecting');
+    expect(await getInspectStateKind(page)).toBe('inspecting');
+  });
+});

--- a/e2e/overlay-notifications.spec.ts
+++ b/e2e/overlay-notifications.spec.ts
@@ -27,11 +27,16 @@ test.describe('Overlay notifications panel', () => {
     await expect(historyHeader(page)).toBeVisible();
   });
 
-  test('panel shows an empty state before any slowdowns', async ({ page }) => {
+  test('panel renders the slowdown history chrome', async ({ page }) => {
     await notificationsButton(page).click();
     await expect(historyHeader(page)).toBeVisible();
+    // The "Clear all events" control is always present in the history panel,
+    // unlike the "No Events" empty state which disappears if React Scan
+    // incidentally records a slow render (e.g. under CPU contention).
     await expect(
-      page.locator(`${TOOLBAR_SELECTORS.widget} >> text=No Events`),
+      page.locator(
+        `${TOOLBAR_SELECTORS.widget} button[title="Clear all events"]`,
+      ),
     ).toBeVisible();
   });
 

--- a/e2e/overlay-notifications.spec.ts
+++ b/e2e/overlay-notifications.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  gotoFixture,
+  notificationsButton,
+  toolbarWidget,
+  getInspectStateKind,
+  waitForToolbarReady,
+  TOOLBAR_SELECTORS,
+} from './helpers';
+
+const historyHeader = (page: Page) =>
+  page.locator(`${TOOLBAR_SELECTORS.widget} >> text=History`).first();
+
+const widgetHeight = async (page: Page): Promise<number> => {
+  const box = await toolbarWidget(page).boundingBox();
+  return box?.height ?? 0;
+};
+
+test.describe('Overlay notifications panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+    await waitForToolbarReady(page);
+  });
+
+  test('clicking the notifications button opens the panel', async ({ page }) => {
+    await notificationsButton(page).click();
+    await expect(historyHeader(page)).toBeVisible();
+  });
+
+  test('panel shows an empty state before any slowdowns', async ({ page }) => {
+    await notificationsButton(page).click();
+    await expect(historyHeader(page)).toBeVisible();
+    await expect(
+      page.locator(`${TOOLBAR_SELECTORS.widget} >> text=No Events`),
+    ).toBeVisible();
+  });
+
+  test('clicking the notifications button again closes the panel', async ({
+    page,
+  }) => {
+    const minimizedHeight = await widgetHeight(page);
+
+    await notificationsButton(page).click();
+    await expect
+      .poll(async () => widgetHeight(page))
+      .toBeGreaterThan(minimizedHeight + 50);
+
+    await notificationsButton(page).click();
+    await expect
+      .poll(async () => widgetHeight(page))
+      .toBeLessThan(minimizedHeight + 50);
+  });
+
+  test('opening notifications turns inspection off', async ({ page }) => {
+    await notificationsButton(page).click();
+    await expect(historyHeader(page)).toBeVisible();
+    expect(await getInspectStateKind(page)).toBe('inspect-off');
+  });
+
+  test('a slow interaction is recorded and surfaced in the panel', async ({
+    page,
+  }) => {
+    await page.click('[data-testid="trigger-slow"]');
+    await page.waitForTimeout(1500);
+
+    await notificationsButton(page).click();
+    await expect(historyHeader(page)).toBeVisible();
+
+    await expect
+      .poll(
+        async () =>
+          page
+            .locator(`${TOOLBAR_SELECTORS.widget} >> text=No Events`)
+            .count(),
+        { timeout: 10_000 },
+      )
+      .toBe(0);
+  });
+});

--- a/e2e/overlay-toolbar.spec.ts
+++ b/e2e/overlay-toolbar.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import {
+  gotoFixture,
+  toolbarWidget,
+  inspectButton,
+  notificationsButton,
+  outlineToggle,
+  getInspectStateKind,
+  waitForInspectStateKind,
+  waitForToolbarReady,
+  isOutlineInstrumentationPaused,
+  TOOLBAR_SELECTORS,
+} from './helpers';
+
+test.describe('Overlay toolbar UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+    await waitForToolbarReady(page);
+  });
+
+  test('renders the toolbar widget and its core controls', async ({ page }) => {
+    await expect(toolbarWidget(page)).toBeVisible();
+    await expect(inspectButton(page)).toBeVisible();
+    await expect(notificationsButton(page)).toBeVisible();
+    await expect(inspectButton(page)).toHaveAttribute('title', 'Inspect element');
+    await expect(notificationsButton(page)).toHaveAttribute(
+      'title',
+      'Notifications',
+    );
+  });
+
+  test('FPS meter is rendered in the toolbar', async ({ page }) => {
+    const fpsLabel = page.locator(`${TOOLBAR_SELECTORS.widget} >> text=FPS`);
+    await expect(fpsLabel).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('clicking inspect button enters inspecting mode', async ({ page }) => {
+    expect(await getInspectStateKind(page)).toBe('inspect-off');
+
+    await inspectButton(page).click();
+    await waitForInspectStateKind(page, 'inspecting');
+    expect(await getInspectStateKind(page)).toBe('inspecting');
+  });
+
+  test('inspect button icon color reflects inspecting state', async ({
+    page,
+  }) => {
+    const inactiveColor = await inspectButton(page).evaluate(
+      (el) => (el as HTMLElement).style.color,
+    );
+    expect(inactiveColor).toBe('rgb(153, 153, 153)');
+
+    await inspectButton(page).click();
+    await waitForInspectStateKind(page, 'inspecting');
+
+    await expect
+      .poll(async () =>
+        inspectButton(page).evaluate((el) => (el as HTMLElement).style.color),
+      )
+      .toBe('rgb(142, 97, 227)');
+  });
+
+  test('clicking inspect button twice toggles inspecting off', async ({
+    page,
+  }) => {
+    await inspectButton(page).click();
+    await waitForInspectStateKind(page, 'inspecting');
+
+    await inspectButton(page).click();
+    await waitForInspectStateKind(page, 'inspect-off');
+    expect(await getInspectStateKind(page)).toBe('inspect-off');
+  });
+
+  test('outline toggle starts enabled (instrumentation active)', async ({
+    page,
+  }) => {
+    await expect(outlineToggle(page)).toBeChecked();
+    expect(await isOutlineInstrumentationPaused(page)).toBe(false);
+  });
+
+  test('toggling outlines off pauses instrumentation and persists', async ({
+    page,
+  }) => {
+    await outlineToggle(page).click();
+
+    await expect
+      .poll(async () => isOutlineInstrumentationPaused(page))
+      .toBe(true);
+    await expect(outlineToggle(page)).not.toBeChecked();
+
+    const persistedEnabled = await page.evaluate(() => {
+      const raw = localStorage.getItem('react-scan-options');
+      return raw ? JSON.parse(raw).enabled : null;
+    });
+    expect(persistedEnabled).toBe(false);
+  });
+
+  test('toggling outlines off then on restores instrumentation', async ({
+    page,
+  }) => {
+    await outlineToggle(page).click();
+    await expect
+      .poll(async () => isOutlineInstrumentationPaused(page))
+      .toBe(true);
+
+    await outlineToggle(page).click();
+    await expect
+      .poll(async () => isOutlineInstrumentationPaused(page))
+      .toBe(false);
+    await expect(outlineToggle(page)).toBeChecked();
+  });
+});

--- a/e2e/overlay-toolbar.spec.ts
+++ b/e2e/overlay-toolbar.spec.ts
@@ -30,8 +30,15 @@ test.describe('Overlay toolbar UI', () => {
   });
 
   test('FPS meter is rendered in the toolbar', async ({ page }) => {
-    const fpsLabel = page.locator(`${TOOLBAR_SELECTORS.widget} >> text=FPS`);
-    await expect(fpsLabel).toBeVisible({ timeout: 10_000 });
+    // The meter starts blank and only paints once its 200ms sampling interval
+    // ticks, which can lag under CPU contention, so poll the widget text.
+    await expect
+      .poll(
+        async () =>
+          toolbarWidget(page).evaluate((el) => el.textContent ?? ''),
+        { timeout: 20_000 },
+      )
+      .toContain('FPS');
   });
 
   test('clicking inspect button enters inspecting mode', async ({ page }) => {

--- a/e2e/overlay-widget.spec.ts
+++ b/e2e/overlay-widget.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import {
+  gotoFixture,
+  toolbarWidget,
+  notificationsButton,
+  isReactScanActive,
+  waitForToolbarReady,
+  TOOLBAR_SELECTORS,
+} from './helpers';
+
+const LOCALSTORAGE_WIDGET_KEY = 'react-scan-widget-settings-v2';
+
+test.describe('Overlay widget container', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+    await waitForToolbarReady(page);
+  });
+
+  test('widget mounts with the expected identity attributes', async ({
+    page,
+  }) => {
+    const widget = toolbarWidget(page);
+    await expect(widget).toBeVisible();
+    await expect(widget).toHaveAttribute('dir', 'ltr');
+  });
+
+  test('widget fades in to full opacity', async ({ page }) => {
+    await expect
+      .poll(async () =>
+        toolbarWidget(page).evaluate((el) =>
+          Number(getComputedStyle(el).opacity),
+        ),
+      )
+      .toBeGreaterThan(0.9);
+  });
+
+  test('all four resize handles are present in the DOM', async ({ page }) => {
+    const handles = page.locator(
+      `${TOOLBAR_SELECTORS.root} .resize-left, ${TOOLBAR_SELECTORS.root} .resize-right, ${TOOLBAR_SELECTORS.root} .resize-top, ${TOOLBAR_SELECTORS.root} .resize-bottom`,
+    );
+    await expect(handles).toHaveCount(4);
+  });
+
+  test('widget settings are persisted to localStorage', async ({ page }) => {
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          (key) => localStorage.getItem(key) !== null,
+          LOCALSTORAGE_WIDGET_KEY,
+        ),
+      )
+      .toBe(true);
+
+    const settings = await page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, LOCALSTORAGE_WIDGET_KEY);
+    expect(settings).not.toBeNull();
+    expect(settings.corner).toBeTruthy();
+    expect(settings.dimensions).toBeTruthy();
+  });
+
+  test('widget survives repeated host-app interactions', async ({ page }) => {
+    for (let clickIndex = 0; clickIndex < 5; clickIndex++) {
+      await page.click('[data-testid="increment"]');
+    }
+    await expect(toolbarWidget(page)).toBeVisible();
+    expect(await isReactScanActive(page)).toBe(true);
+  });
+
+  test('opening a panel expands the widget', async ({ page }) => {
+    const minimizedBox = await toolbarWidget(page).boundingBox();
+    expect(minimizedBox).not.toBeNull();
+
+    await notificationsButton(page).click();
+    await page.waitForTimeout(600);
+
+    await expect
+      .poll(async () => {
+        const box = await toolbarWidget(page).boundingBox();
+        return box?.width ?? 0;
+      })
+      .toBeGreaterThan(minimizedBox?.width ?? 0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The existing e2e suite mostly pokes at React Scan internals through `window.__REACT_SCAN__` and rarely drives the actual Preact overlay UI. This PR adds **deep, interaction-driven Playwright tests** that exercise the real overlay interface mounted inside the shadow root — clicking the toolbar controls, running the full inspect→focus→inspect flow, opening the notifications panel, and asserting widget container behavior.

Playwright CSS locators pierce the open shadow root, so the tests target the overlay's actual buttons, toggles, and panels rather than reaching into signals.

## What's added

New helpers in `e2e/helpers.ts`:
- Centralized overlay selectors (`TOOLBAR_SELECTORS`) and an `InspectStateKind` type.
- `getInspectStateKind` / `waitForInspectStateKind`, `isOutlineInstrumentationPaused`.
- Locator getters (`toolbarWidget`, `inspectButton`, `notificationsButton`, `outlineToggle`) and `waitForToolbarReady`.
- `enterInspectMode` and `focusComponent` — the latter drives raw pointer coordinates because the overlay's full-screen event-catcher obscures element-targeted clicks while inspecting.
- `clickToolbarControl` (dispatches the click directly so resize handles overlapping a control can't swallow it) and `blurOverlay` (restores page focus for the global Escape shortcut).

New specs:
- **`e2e/overlay-toolbar.spec.ts`** — toolbar renders with its controls; FPS meter paints; inspect button enters/exits inspecting mode and its icon color reflects state; the outline toggle pauses/resumes instrumentation and persists `react-scan-options` to localStorage.
- **`e2e/overlay-inspector.spec.ts`** — full inspect→focus flow: overlay canvas activates, clicking a component focuses it and opens the inspector panel + component tree, the header shows the component name, the copy button appears, the close button returns to `inspect-off`, Escape steps focused→inspecting, and re-focusing keeps the inspector open.
- **`e2e/overlay-notifications.spec.ts`** — notifications button opens/closes the panel (verified via widget expansion), opening turns inspection off, the slowdown-history chrome renders, and a deliberately slow interaction is recorded and surfaced.
- **`e2e/overlay-widget.spec.ts`** — widget mounts with expected attributes, fades in, exposes all four resize handles, persists widget settings to localStorage, survives repeated host-app interactions, and expands when a panel opens.

## Testing

- `pnpm build` ✅
- `pnpm test:e2e` ✅ (all new overlay tests pass)
- Stability: ran the four new specs with `--repeat-each` (84/84 and 52/52 passing) to eliminate flakiness from the FPS sampling interval and from React Scan incidentally recording a slow render under CPU contention.

### Notes
- No source files were changed — tests only.
- Pre-existing repo-wide `pnpm lint`/`pnpm format:check`/`pnpm typecheck` issues are untouched and unrelated to these tests (e.g. `ban-ts-comment` in `core/utils.ts`, a deprecated tsconfig option in `packages/extension`, and the repo not being oxfmt-formatted). The new files follow the established style of the existing `e2e/` specs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8600624-da35-49a4-8dce-bc68506bd9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8600624-da35-49a4-8dce-bc68506bd9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

